### PR TITLE
jenkins_build.sh: Add error check for the in-container bash code

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -333,6 +333,7 @@ deploy_to_s3() {
 			groupadd -g $DEPLOYER_GID deployer
 			useradd -m -u $DEPLOYER_UID -g $DEPLOYER_GID deployer
 			su deployer<<EOSU
+set -ex
 echo "${BUILD_VERSION}" > "/host/images/${SLUG}/latest"
 if [ "$DEPLOY_ARTIFACT" = "docker-image" ] || [ "$DEVICE_STATE" = "DISCONTINUED" ]; then
 	echo "WARNING: No raw image prepare step for docker images only artifacts or discontinued device types."


### PR DESCRIPTION
The in-container bash code can also error so we need to make sure
we propagate this error outside the container so Jenkins fails and
marks the build job accordingly.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>