### PR TITLE
git: Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 barys.log
 build/node_modules
 *.log
+build/package-lock.json


### PR DESCRIPTION
Since this file seems to be generated by the barys script and it's not
supposed to be checked in, let's ignore it.

Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>