### PR TITLE
jenkins_build.sh: Do not error if the kernel headers are not generated

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -72,8 +72,8 @@ deploy_build () {
 		return
 	fi
 
-	cp -v "$YOCTO_BUILD_DEPLOY/kernel_modules_headers.tar.gz" "$_deploy_dir"
-	cp -v "$YOCTO_BUILD_DEPLOY/kernel_source.tar.gz" "$_deploy_dir"
+	cp -v "$YOCTO_BUILD_DEPLOY/kernel_modules_headers.tar.gz" "$_deploy_dir" || true
+	cp -v "$YOCTO_BUILD_DEPLOY/kernel_source.tar.gz" "$_deploy_dir" || true
 	if [ "${_compressed}" != 'true' ]; then
 		# uncompressed, just copy and we're done
 		cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/$_deploy_artifact") "$_deploy_dir/image/balena.img"


### PR DESCRIPTION
We have customers that do not want to have the kernel modules headers generated.
So let's make sure the deploy won't fail when these headers are not present.

Change-type: patch
Changelog-entry: Do not error if the kernel headers are not generated
Signed-off-by: Florin Sarbu <florin@balena.io>