### PR TITLE
jenkins_build.sh: Deploy the device type logo

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -74,6 +74,7 @@ deploy_build () {
 
 	cp -v "$YOCTO_BUILD_DEPLOY/kernel_modules_headers.tar.gz" "$_deploy_dir" || true
 	cp -v "$YOCTO_BUILD_DEPLOY/kernel_source.tar.gz" "$_deploy_dir" || true
+	cp -v "$MACHINE.svg" "$_deploy_dir"
 	if [ "${_compressed}" != 'true' ]; then
 		# uncompressed, just copy and we're done
 		cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/$_deploy_artifact") "$_deploy_dir/image/balena.img"


### PR DESCRIPTION
This is needed so that the UI can pick it up.

Change-type: patch
Changelog-entry: Deploy the device type logo so the UI can pick it up
Signed-off-by: Florin Sarbu <florin@balena.io>