### PR TITLE
jenkins_build.sh: Switch s3cmd with s4cmd

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -319,7 +319,7 @@ deploy_to_s3() {
 		exit 1
 	fi
 
-	local _s3_cmd="s3cmd --access_key=${_s3_access_key} --secret_key=${_s3_secret_key}"
+	local _s3_cmd="s4cmd --access_key=${_s3_access_key} --secret_key=${_s3_secret_key}"
 	local _s3_sync_opts="--recursive --acl-public"
 	docker pull resin/resin-img:master
 	docker run --rm -t \
@@ -336,7 +336,7 @@ deploy_to_s3() {
 		-e DEVICE_STATE="$DEVICE_STATE" \
 		-v $_s3_deploy_dir:/host/images resin/resin-img:master /bin/sh -x -e -c ' \
 			apt-get -y update
-			apt-get install -y s3cmd
+			apt-get install -y s4cmd
 			echo "Creating and setting deployer user $DEPLOYER_UID:$DEPLOYER_GID."
 			groupadd -g $DEPLOYER_GID deployer
 			useradd -m -u $DEPLOYER_UID -g $DEPLOYER_GID deployer


### PR DESCRIPTION
The resin-img docker image has changed to open-balena-base 8.0.0
which in turn is based on debian:buster. This version of debian
does not include the s3cmd package in it's repositories anymore.
Instead it provides a replacement package called s4cmd
(https://packages.debian.org/buster/s4cmd) which "is intended as
an alternative to the existing s3cmd tool, enhancing performance
and support for large files, and coming with a number of additional
features and fixes".

Change-type: minor
Signed-off-by: Florin Sarbu <florin@balena.io>