### PR TITLE
jenkins_build.sh: Use dsync instead of deprecated sync command

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -351,7 +351,7 @@ if [ -z "$($S3_CMD ls s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/)" ] || [ -n "$
 	touch /host/images/${SLUG}/${BUILD_VERSION}/IGNORE
 	$S3_CMD del -rf s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}
 	$S3_CMD put /host/images/${SLUG}/${BUILD_VERSION}/IGNORE s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/
-	$S3_CMD $S3_SYNC_OPTS sync /host/images/${SLUG}/${BUILD_VERSION}/ s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/
+	$S3_CMD $S3_SYNC_OPTS dsync /host/images/${SLUG}/${BUILD_VERSION}/ s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/
 	if [ "${DEVELOPMENT_IMAGE}" = "no" ]; then
 		$S3_CMD put /host/images/${SLUG}/latest s3://${S3_BUCKET}/${SLUG}/ --API-ACL=public-read -f
 	fi


### PR DESCRIPTION
The sync command is deprecated in s4cmd in favour of dsync. And also
the existing deprecated sync command in s4cmd does the sync in a
different manner from the s3cmd sync command in the sense that it
makes a copy of the local dir in the remote dir and in our case we
end up with duplicate dirs in the target path.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>