### PR TITLE
barys: correctly apply SUPERVISOR_TAG variable in local.conf

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -435,7 +435,9 @@ if [ -n "$SHARED_SSTATE" ]; then
     sed -i "s#.*SSTATE_DIR ?=.*#SSTATE_DIR ?= \"$SHARED_SSTATE\"#g" conf/local.conf
 fi
 if [ -n "$SUPERVISOR_TAG" ]; then
-    sed -i "s/.*SUPERVISOR_TAG ?=.*/SUPERVISOR_TAG ?= \"$SUPERVISOR_TAG\"/g" conf/local.conf
+    grep -q 'SUPERVISOR_TAG ?=' conf/local.conf \
+    && sed -i "s/.*SUPERVISOR_TAG ?=.*/SUPERVISOR_TAG ?= \"$SUPERVISOR_TAG\"/g" conf/local.conf \
+    || echo "SUPERVISOR_TAG ?= $SUPERVISOR_TAG" >> conf/local.conf
 fi
 
 perl -i -pe 'BEGIN {$/ = undef}; s/^\n# Barys: Additional variables.*//sm' conf/local.conf


### PR DESCRIPTION
Setting `--supervisor-tag` to enable building for a specific supervisor tag sets the `SUPERVISOR_TAG` value. That is the correct variable to set according to meta-balena (see at https://github.com/balena-os/meta-balena/blob/8d5057b45e1965e6c27c03a95d2211ae47842331/meta-balena-common/recipes-containers/resin-supervisor/resin-supervisor.inc#L20 ) but in the device types' `local.conf.sample` the `TARGET_TAG` variable was set, see for example https://github.com/balena-os/balena-raspberrypi/blob/078b0add0345e94f27c15d98256f8c7b61b66761/layers/meta-balena-raspberrypi/conf/samples/local.conf.sample#L45-L46 and thus barys' setting was not applied.

Looking at the available recipes, the `SUPERVISOR_TAG` should be set and in the device types' `local.conf.example` files should be updated to refer to that instead of `TARGET_TAG`.

With this change this can be implemented in two steps:

* the current PR updates `SUPERVISOR_TAG` if exists or appends if it doesn't (or the
  update has failed) in local.conf and allows using the relevant barys flag again
* in other per-device repo PRs then the `local.conf.example` can separately updated,
  to be less misleading, on its own schedule

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>