### PR TITLE
Remove ESR-line information from the release

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -158,13 +158,6 @@ while [[ $# -ge 1 ]]; do
 			fi
 			supervisorTag="${supervisorTag:-$2}"
 			;;
-		--esr-line)
-			if [ -z "$2" ]; then
-				echo "--esr-line argument can take a value between: next, current, sunset, the default value is __ignore__)"
-				exit 1
-			fi
-			esrLine="${esrLine:-$2}"
-			;;
 		--preserve-build)
 			BARYS_ARGUMENTS_VAR=""
 			;;
@@ -179,7 +172,6 @@ JENKINS_DL_DIR=$JENKINS_PERSISTENT_WORKDIR/shared-downloads
 JENKINS_SSTATE_DIR=$JENKINS_PERSISTENT_WORKDIR/$MACHINE/sstate
 metaResinBranch=${metaResinBranch:-__ignore__}
 supervisorTag=${supervisorTag:-__ignore__}
-esrLine=${esrLine:-__ignore__}
 
 # Sanity checks
 if [ -z "$MACHINE" ] || [ -z "$JENKINS_PERSISTENT_WORKDIR" ] || [ -z "$buildFlavor" ]; then
@@ -315,7 +307,6 @@ deploy_to_balena() {
 		-e DEVELOPMENT_IMAGE=$DEVELOPMENT_IMAGE \
 		-e DEPLOY_TO=$deployTo \
 		-e VERSION_HOSTOS=$VERSION_HOSTOS \
-		-e ESR_LINE=$esrLine \
 		-v $_exported_image_path:/host/resin-image.docker \
 		--privileged \
 		resin/balena-push-env /start-docker-and-push.sh

--- a/automation/start-docker-and-push.sh
+++ b/automation/start-docker-and-push.sh
@@ -20,18 +20,6 @@ else
 	balena login --token $BALENAOS_PRODUCTION_TOKEN
 fi
 
-case $ESR_LINE in
-	next|current|sunset)
-		SLUG="${SLUG}-esr"
-		;;
-	__ignore__)
-		;;
-	*)
-		echo "Invalid ESR line"
-		exit 1
-		;;
-esac
-
 echo "[INFO] Pushing $_local_image to balenaos/$SLUG"
 
 _releaseID=$(balena deploy "balenaos/$SLUG" "$_local_image" | sed -n 's/.*Release: //p')
@@ -43,10 +31,6 @@ fi
 
 balena tag set version $VERSION_HOSTOS --release $_releaseID
 balena tag set variant $_variant --release $_releaseID
-balena tag set status "Untested" --release $_releaseID
-if [ "$ESR_LINE" != "__ignore__" ]; then
-	balena tag set "ESR-line" $ESR_LINE --release $_releaseID
-fi
 
 cleanup
 exit 0


### PR DESCRIPTION
Also removes "Untested" tag from releases, this was needed for nightly
builds but should be added back only when the rest of that work is in
place

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@balena.io>