### PR TITLE
jenkins_build.sh: Set a content-type to the device type's logo.svg

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -384,6 +384,7 @@ if [ -z "$($S3_CMD ls s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/)" ] || [ -n "$
 	if [ "${DEVELOPMENT_IMAGE}" = "no" ]; then
 		$S3_CMD put /host/images/${SLUG}/latest s3://${S3_BUCKET}/${SLUG}/ --API-ACL=public-read -f
 	fi
+	$S3_CMD put /host/images/${SLUG}/${BUILD_VERSION}/logo.svg s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/ --API-ACL=public-read -f --API-ContentType=image/svg+xml
 	$S3_CMD del s3://${S3_BUCKET}/${SLUG}/${BUILD_VERSION}/IGNORE
 else
 	echo "WARNING: Deployment already done for ${SLUG} at version ${BUILD_VERSION}"


### PR DESCRIPTION
This is needed so that browsers can load the logo.
Since s4cmd doesn't have a `modify` command, I
had to `put` the logo again.

Change-type: patch
Connects-to: #166
HQ: https://github.com/balena-io/balena/issues/1818
See: https://github.com/bloomreach/s4cmd#--api-contenttypestring
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>