### PR TITLE
jenkins: deploy test suite from meta-balena

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -111,6 +111,12 @@ deploy_build () {
 			rm -rf $_deploy_dir/image/resin-flasher.img
 		fi
 	fi
+
+	if [ -d "${WORKSPACE}/layers/meta-balena/tests" ]
+	then
+		# copy all leviathan/testbot tests from meta-balena to the deploy dir
+		cp -av "${WORKSPACE}/layers/meta-balena/tests" "$_deploy_dir/tests"
+	fi
 }
 
 rootdir="$( cd "$( dirname "$0" )" && pwd )/../../"


### PR DESCRIPTION
If leviathan test suites are found in the checkout of
meta-balena we should package them up with the jenkins artifacts.

Change-type: patch
Connects-to: https://github.com/balena-os/meta-balena/pull/2113
Signed-off-by: Kyle Harding <kyle@balena.io>