### PR TITLE
balena-yocto-scripts: rename resin image types to balena

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -72,7 +72,7 @@ deploy_build () {
 	cp -v "$YOCTO_BUILD_DEPLOY/VERSION" "$_deploy_dir"
 	cp -v "$YOCTO_BUILD_DEPLOY/VERSION_HOSTOS" "$_deploy_dir"
 	cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/$_image-$MACHINE.manifest") "$_deploy_dir/$_image-$MACHINE.manifest"
-	cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/resin-image-$MACHINE.docker") "$_deploy_dir/resin-image.docker"
+	cp -v $(readlink --canonicalize "$YOCTO_BUILD_DEPLOY/balena-image-$MACHINE.docker") "$_deploy_dir/balena-image.docker"
 
 	test "$SLUG" = "edge" && return
 
@@ -336,7 +336,7 @@ deploy_images () {
 	# Make sure the tags are valid
 	# https://github.com/docker/docker/blob/master/vendor/github.com/docker/distribution/reference/regexp.go#L37
 	local _tag="$(echo $VERSION_HOSTOS$_variant-$SLUG | sed 's/[^a-z0-9A-Z_.-]/_/g')"
-	local _exported_image_path=$(readlink --canonicalize $WORKSPACE/build/tmp/deploy/images/$MACHINE/resin-image-$MACHINE.docker)
+	local _exported_image_path=$(readlink --canonicalize $WORKSPACE/build/tmp/deploy/images/$MACHINE/balena-image-$MACHINE.docker)
 
 	echo "[INFO] Pushing image to dockerhub $_docker_repo:$_tag..."
 

--- a/build/barys
+++ b/build/barys
@@ -55,7 +55,7 @@ function help {
     echo -e "\t\t\t stopping"
 
     echo -e "\t-c | --compress"
-    echo -e "\t\t Run build with compress variable (RESIN_SDIMG_COMPRESSION)"
+    echo -e "\t\t Run build with compress variable (BALENA_SDIMG_COMPRESSION)"
     echo -e "\t\t using $COMPRESS_TOOL."
     echo -e "\t\t Default: no."
 
@@ -407,13 +407,13 @@ if [ "x$REMOVEBUILD" == "xyes" ]; then
     rm -rf $SCRIPTPATH/../../$BUILD_DIR
 fi
 
-RESIN_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/ | grep meta-balena-)
+BALENA_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/ | grep meta-balena-)
 
 # Configure build
 
-$SCRIPTPATH/generate-conf-notes.sh $SCRIPTPATH/../../layers/${RESIN_MACHINE_LAYER}/conf/ ${DEVICE_TYPES_JSONS}
+$SCRIPTPATH/generate-conf-notes.sh $SCRIPTPATH/../../layers/${BALENA_MACHINE_LAYER}/conf/ ${DEVICE_TYPES_JSONS}
 
-export TEMPLATECONF=${SCRIPTPATH}/../../layers/${RESIN_MACHINE_LAYER}/conf/samples
+export TEMPLATECONF=${SCRIPTPATH}/../../layers/${BALENA_MACHINE_LAYER}/conf/samples
 source ${SCRIPTPATH}/../../layers/poky/oe-init-build-env ${SCRIPTPATH}/../../${BUILD_DIR}
 if [ "x$DEVELOPMENT_IMAGE" == "xyes" ]; then
     sed -i "s/.*DEVELOPMENT_IMAGE =.*/DEVELOPMENT_IMAGE = \"1\"/g" conf/local.conf
@@ -423,7 +423,7 @@ else
     sed -i "s/.*RESINHUP ?=.*/RESINHUP ?= \"yes\"/g" conf/local.conf
 fi
 if [ "x$COMPRESS" == "xyes" ]; then
-    sed -i "s/.*RESIN_RAW_IMG_COMPRESSION ?=.*/RESIN_RAW_IMG_COMPRESSION ?= \"${COMPRESS_TOOL}\"/g" conf/local.conf
+    sed -i "s/.*BALENA_RAW_IMG_COMPRESSION ?=.*/BALENA_RAW_IMG_COMPRESSION ?= \"${COMPRESS_TOOL}\"/g" conf/local.conf
 fi
 if [ "x$RM_WORK" == "xyes" ]; then
     sed -i "s/.*INHERIT += \"rm_work\".*/INHERIT += \"rm_work\"/g" conf/local.conf


### PR DESCRIPTION
As part of a full rename away from legacy resin namespaces the
following device compatibility changes are required to align
with meta-balena changes.

- packaging scripts

Change-type: minor
Changelog-entry: Rename resin image types to balena
Depends-on: balena-os/meta-balena#2118
Signed-off-by: Kyle Harding <kyle@balena.io>