### PR TITLE
jenkins: compress test suites inside jenkins artifacts

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -114,8 +114,9 @@ deploy_build () {
 
 	if [ -d "${WORKSPACE}/layers/meta-balena/tests" ]
 	then
-		# copy all leviathan/testbot tests from meta-balena to the deploy dir
-		cp -av "${WORKSPACE}/layers/meta-balena/tests" "$_deploy_dir/tests"
+		# package all leviathan/testbot tests from meta-balena to the deploy dir
+		# make sure they are compressed so a flattened unzip of artifacts does not fail
+		tar -czvf "$_deploy_dir/tests.tar.gz" "${WORKSPACE}/layers/meta-balena/tests"
 	fi
 }
 


### PR DESCRIPTION
The jenkins leviathan builds will attempt to flatten these artifacts on extract (`unzip -j`) so make sure the test suites are a separate tarball inside the artifacts.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>