### PR TITLE
Dynamically build helper containers

### DIFF
--- a/automation/balena-lib.sh
+++ b/automation/balena-lib.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BALENA_YOCTO_SCRIPTS_REVISION=$(cd "${script_dir}" && git rev-parse --short HEAD)
+
+# Pull a helper image building a matching version if required
+# Inputs:
+# $1: Dockerfile name
+docker_pull_helper_image() {
+	local _dockerfile_name="$1"
+	local _image_name=""
+	local _image_prefix=""
+	_image_name="${_dockerfile_name%".template"}"
+	_image_name="${_image_name#"Dockerfile_"}"
+	case ${_dockerfile_name} in
+		*template)
+			_image_prefix="${MACHINE}-"
+			export DEVICE_ARCH=$(jq --raw-output '.arch' "$WORKSPACE/$MACHINE.json")
+			export DEVICE_TYPE=${MACHINE}
+			;;
+	esac
+
+	if ! docker pull "${NAMESPACE}"/"${_image_prefix}""${_image_name}":"${BALENA_YOCTO_SCRIPTS_REVISION}"; then
+		DOCKERHUB_USER="${DOCKERHUB_USER:-"balenadevices"}"
+		DOCKERHUB_PWD=${DOCKERHUB_PWD:-"balenadevicesDockerhubPassword"}
+		echo "Login to docker as ${DOCKERHUB_USER}"
+		docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
+		JOB_NAME="${JOB_NAME}" DOCKERFILES="${_dockerfile_name}" "${script_dir}/jenkins_build-containers.sh"
+	fi
+}

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -47,6 +47,9 @@ cleanup() {
 }
 trap 'cleanup fail' SIGINT SIGTERM
 
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${script_dir}/balena-lib.sh"
+
 deploy_build () {
 	local _deploy_dir="$1"
 	local _remove_compressed_file="$2"
@@ -248,7 +251,9 @@ mkdir -p $JENKINS_SSTATE_DIR
 # Run build
 docker stop $BUILD_CONTAINER_NAME 2> /dev/null || true
 docker rm --volumes $BUILD_CONTAINER_NAME 2> /dev/null || true
-docker pull ${NAMESPACE}/yocto-build-env
+if ! docker_pull_helper_image "Dockerfile_yocto-build-env"; then
+	exit 1
+fi
 docker run ${REMOVE_CONTAINER} \
     -v $WORKSPACE:/yocto/resin-board \
     -v $JENKINS_DL_DIR:/yocto/shared-downloads \
@@ -355,7 +360,9 @@ deploy_images () {
 
 deploy_to_balena() {
 	local _exported_image_path=$1
-	docker pull ${NAMESPACE}/balena-push-env
+	if ! docker_pull_helper_image "Dockerfile_balena-push-env"; then
+		exit 1
+	fi
 	docker run --rm -t \
 		-e BASE_DIR=/host \
 		-e BALENAOS_STAGING_TOKEN=$BALENAOS_STAGING_TOKEN \


### PR DESCRIPTION
Instead of using the master tag for helper containers, use those with a tag that matches the repository revision building them if required.

This allows to make changes to the helper containers without affecting the build of previous releases.