### PR TITLE
Use version controlled helper containers

### DIFF
--- a/automation/Dockerfile_balena-push-env
+++ b/automation/Dockerfile_balena-push-env
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y build-essential curl unzip
 RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*
 RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 ENV NODE_VERSION node_8.x
-ENV DISTRO xenial
+ENV DISTRO bionic
 RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list &&\
   echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/lists/*

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -1,8 +1,12 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
                                          texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
+                                         python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
+                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty
@@ -13,7 +17,7 @@ ENV LANG en_US.UTF-8
 RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*
 RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 ENV NODE_VERSION node_8.x
-ENV DISTRO xenial
+ENV DISTRO bionic
 RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list &&\
   echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/lists/*

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -30,6 +30,13 @@ VOLUME /var/lib/docker
 RUN wget -q -O /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} && chmod +x /usr/bin/docker \
     && echo "${DOCKER_SHA256}" /usr/bin/docker | sha256sum -c -
 
+# Install balena-cli
+ENV BALENA_CLI_VERSION 11.35.4
+RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA_CLI_VERSION/balena-cli-v$BALENA_CLI_VERSION-linux-x64-standalone.zip > balena-cli.zip && \
+  unzip balena-cli.zip && \
+  mv balena-cli/* /usr/bin && \
+  rm -rf balena-cli.zip balena-cli
+
 COPY manage-docker.sh /
 COPY prepare-and-start.sh /
 

--- a/automation/balena-lib.sh
+++ b/automation/balena-lib.sh
@@ -22,7 +22,7 @@ docker_pull_helper_image() {
 
 	if ! docker pull "${NAMESPACE}"/"${_image_prefix}""${_image_name}":"${BALENA_YOCTO_SCRIPTS_REVISION}"; then
 		DOCKERHUB_USER="${DOCKERHUB_USER:-"balenadevices"}"
-		DOCKERHUB_PWD=${DOCKERHUB_PWD:-"balenadevicesDockerhubPassword"}
+		DOCKERHUB_PWD=${DOCKERHUB_PWD:-"${balenadevicesDockerhubPassword}"}
 		echo "Login to docker as ${DOCKERHUB_USER}"
 		docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
 		JOB_NAME="${JOB_NAME}" DOCKERFILES="${_dockerfile_name}" "${script_dir}/jenkins_build-containers.sh"

--- a/automation/balena-lib.sh
+++ b/automation/balena-lib.sh
@@ -10,6 +10,7 @@ docker_pull_helper_image() {
 	local _dockerfile_name="$1"
 	local _image_name=""
 	local _image_prefix=""
+	local _retvalue="$2"
 	_image_name="${_dockerfile_name%".template"}"
 	_image_name="${_image_name#"Dockerfile_"}"
 	case ${_dockerfile_name} in
@@ -27,4 +28,5 @@ docker_pull_helper_image() {
 		docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
 		JOB_NAME="${JOB_NAME}" DOCKERFILES="${_dockerfile_name}" "${script_dir}/jenkins_build-containers.sh"
 	fi
+	eval "$_retvalue"='${BALENA_YOCTO_SCRIPTS_REVISION}'
 }

--- a/automation/jenkins_build-containers.sh
+++ b/automation/jenkins_build-containers.sh
@@ -4,7 +4,8 @@ set -ev
 
 DOCKERFILES=( Dockerfile_yocto-build-env Dockerfile_balena-push-env )
 
-REVISION=$(git rev-parse --short HEAD)
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+REVISION=$(cd "${script_dir}" && git rev-parse --short HEAD)
 NAMESPACE=${NAMESPACE:-resin}
 
 # Get the absolute script location

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -251,7 +251,7 @@ mkdir -p $JENKINS_SSTATE_DIR
 # Run build
 docker stop $BUILD_CONTAINER_NAME 2> /dev/null || true
 docker rm --volumes $BUILD_CONTAINER_NAME 2> /dev/null || true
-if ! docker_pull_helper_image "Dockerfile_yocto-build-env"; then
+if ! docker_pull_helper_image "Dockerfile_yocto-build-env" balena_yocto_scripts_revision; then
 	exit 1
 fi
 docker run ${REMOVE_CONTAINER} \
@@ -267,7 +267,7 @@ docker run ${REMOVE_CONTAINER} \
     -e DEVELOPMENT_IMAGE=$DEVELOPMENT_IMAGE \
     --name $BUILD_CONTAINER_NAME \
     --privileged \
-    ${NAMESPACE}/yocto-build-env \
+    ${NAMESPACE}/yocto-build-env:"${balena_yocto_scripts_revision}" \
     /prepare-and-start.sh \
         --log \
         --machine "$MACHINE" \
@@ -360,7 +360,7 @@ deploy_images () {
 
 deploy_to_balena() {
 	local _exported_image_path=$1
-	if ! docker_pull_helper_image "Dockerfile_balena-push-env"; then
+	if ! docker_pull_helper_image "Dockerfile_balena-push-env" balena_yocto_scripts_revision; then
 		exit 1
 	fi
 	docker run --rm -t \
@@ -375,7 +375,7 @@ deploy_to_balena() {
 		-e META_BALENA_VERSION=$META_BALENA_VERSION \
 		-v $_exported_image_path:/host/appimage.docker \
 		--privileged \
-		${NAMESPACE}/balena-push-env /balena-push-os-version.sh
+		${NAMESPACE}/balena-push-env:${balena_yocto_scripts_revision} /balena-push-os-version.sh
 }
 
 deploy_to_s3() {


### PR DESCRIPTION
This set of commits move the helper containers used to build and push releases to be source controlled instead of using the `latest` version.

This means that from this version onwards we will be able to modify helper scripts and they will only affect releases that use the balena-yocto-script revision that contains the changes.

Note that older revisions that use master will still break is `master` is updated to something that is not working. Those older revisions should be updated to this revision.