### PR TITLE
Dockerfile_yocto-build-env: Install required python3-distutils module

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
                                          texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
-                                         python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
+                                         python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
                                          gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils \
                                          && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Otherwise bitbake fails with the following error:

Your Python 3 is not a full install. Please install the module
distutils.sysconfig (see the Getting Started guide for further
information).

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>