### PR TITLE
Dockerfile_yocto-build-env: Install required git-lfs and bison modules

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -6,6 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales \
                                          texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
                                          python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
+					 git-lfs bison \
                                          gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils \
                                          && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Otherwise bitbake fails with the following error:

The following required tools (as specified by HOSTTOOLS) appear
to be unavailable in PATH, please install them in order to proceed
  git-lfs bison

Change-type: patch
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>