### PR TITLE
barys: Don't use meta-balena-bsp as machine layer

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -407,7 +407,7 @@ if [ "x$REMOVEBUILD" == "xyes" ]; then
     rm -rf $SCRIPTPATH/../../$BUILD_DIR
 fi
 
-BALENA_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/ | grep meta-balena-)
+BALENA_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/ | grep meta-balena- | grep -v -e 'meta-balena-bsp' -e 'meta-balena-distro')
 
 # Configure build
 


### PR DESCRIPTION
Fixes the following:
Error: TEMPLATECONF value points to nonexistent directory

Change-type: Patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>