### PR TITLE
Improve template layer matching

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -407,7 +407,7 @@ if [ "x$REMOVEBUILD" == "xyes" ]; then
     rm -rf $SCRIPTPATH/../../$BUILD_DIR
 fi
 
-BALENA_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/ | grep meta-balena-)
+BALENA_MACHINE_LAYER=$(ls ${SCRIPTPATH}/../../layers/meta-balena*/conf/samples/bblayers.conf.sample | awk -F'/' '{print $(NF-3)}')
 
 # Configure build
 


### PR DESCRIPTION
The current method does not support multiple layers named with names
following `meta-balena-*` so this change will search for the required
`bblayers.conf.sample` file before assigning the template layer.

Change-type: minor
Changelog-entry: Improve template layer matching
Signed-off-by: Kyle Harding <kyle@balena.io>