### PR TITLE
Replace docker with balena-engine in BalenaOS build

### DIFF
--- a/automation/Dockerfile_balena-push-env
+++ b/automation/Dockerfile_balena-push-env
@@ -31,4 +31,4 @@ RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA
   rm -rf balena-cli.zip balena-cli
 
 COPY include/balena-docker.inc include/balena-api.inc entry_scripts/balena-deploy-block.sh /
-WORKDIR /yocto/resin-board
+WORKDIR /work

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -44,4 +44,4 @@ RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA
 COPY include/balena-docker.inc /
 COPY entry_scripts/prepare-and-start.sh /
 
-WORKDIR /yocto/resin-board
+WORKDIR /work

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat g
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-# Additional host packages required by resin
-RUN apt-get update && apt-get install -y apt-transport-https && rm -rf /var/lib/apt/lists/*
+# Additional host packages required by balena
+RUN apt-get update && apt-get install -y apt-transport-https iptables iproute2 procps uidmap && rm -rf /var/lib/apt/lists/*
 RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 ENV NODE_VERSION node_8.x
 ENV DISTRO bionic

--- a/automation/entry_scripts/prepare-and-start.sh
+++ b/automation/entry_scripts/prepare-and-start.sh
@@ -5,6 +5,8 @@ source /balena-docker.inc
 
 trap 'balena_docker_stop fail' SIGINT SIGTERM
 
+INSTALL_DIR="/work"
+
 # Create the normal user to be used for bitbake (barys)
 echo "[INFO] Creating and setting builder user $BUILDER_UID:$BUILDER_GID."
 groupadd -g $BUILDER_GID builder
@@ -44,10 +46,10 @@ sudo -H -u builder git config --get user.email
 
 # Start barys with all the arguments requested
 echo "[INFO] Running build as builder user..."
-if [ -d /yocto/resin-board/balena-yocto-scripts ]; then
-    sudo -H -u builder /yocto/resin-board/balena-yocto-scripts/build/barys $@ &
+if [ -d "${INSTALL_DIR}/balena-yocto-scripts" ]; then
+    sudo -H -u builder "${INSTALL_DIR}/balena-yocto-scripts/build/barys" $@ &
 else
-    sudo -H -u builder /yocto/resin-board/resin-yocto-scripts/build/barys $@ &
+    sudo -H -u builder "${INSTALL_DIR}/resin-yocto-scripts/build/barys" $@ &
 fi
 barys_pid=$!
 wait $barys_pid || true

--- a/automation/include/balena-docker.inc
+++ b/automation/include/balena-docker.inc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -45,8 +45,8 @@ balena_docker_start() {
 	[ ! -d "${_rootDir}" ] && mkdir -p "${_rootDir}"
 
 	__dlog "[INFO]: Starting docker: data root ${_data_dir}, base root dir ${_rootDir}"
-        dockerd --data-root="${_data_dir}" --pidfile="${_rootDir}/docker.pid" --host="unix://${_rootDir}/docker.sock" --iptables=false --ip-masq=false --exec-root="${_rootDir}/ds" > "${_logfile}" 2>&1 &
-        echo "unix://${_rootDir}/docker.sock ${_rootDir}/docker.pid"
+	dockerd --data-root="${_data_dir}" --pidfile="${_rootDir}/docker.pid" --host="unix://${_rootDir}/docker.sock" --iptables=false --ip-masq=false --exec-root="${_rootDir}/ds" > "${_logfile}" 2>&1 &
+	echo "unix://${_rootDir}/docker.sock ${_rootDir}/docker.pid"
 }
 
 # Terminate the dockerd daemon
@@ -76,7 +76,10 @@ balena_docker_stop() {
 		_stime=$(date +%s)
 		_etime=$(date +%s)
 		while [ -f "${_pid_file}" ] && [ -s "${_pid_file}" ] && ps "$(cat "${_pid_file}")" | grep -q docker; do
-			if [ $(( _etime - _stime )) -le "${_timeout}" ]; then
+			# shellcheck disable=SC2003
+			# shellcheck disable=SC2006
+			# Bitbake requires this syntax
+			if [ "`expr "$_etime" - "$_stime"`" -le "${_timeout}" ]; then
 				sleep 1
 				_etime=$(date +%s)
 			else
@@ -87,10 +90,9 @@ balena_docker_stop() {
 	else
 		>&2 echo "[WARN] Can't stop docker container."
 		>&2 echo "[WARN] Your host might have been left with unreleased resources (ex. loop devices)."
-	fi
-
-	if [ "${_fail}" == "fail" ]; then
-		exit 1
+		if [ "${_fail}" = "fail" ]; then
+			exit 1
+		fi
 	fi
 }
 
@@ -104,21 +106,24 @@ balena_docker_stop() {
 # 0 on success, 1 and exit in case of failure
 #
 balena_docker_wait() {
-  local _docker_host=${1:-"unix:///var/run/docker.sock"}
-  local _stime
-  local _etime
-  local _timeout=20
-   __dlog "[INFO] Waiting for docker to initialize..."
-  _stime=$(date +%s)
-  _etime=$(date +%s)
-  until DOCKER_HOST=${_docker_host} docker info >/dev/null 2>&1; do
-      if [ $(( _etime - _stime )) -le ${_timeout} ]; then
-          sleep 1
-          _etime=$(date +%s)
-      else
-          >&2 echo "[ERROR] Timeout while waiting for docker to come up."
-          exit 1
-      fi
-  done
-  __dlog "[INFO] Docker was initialized."
+	local _docker_host=${1:-"unix:///var/run/docker.sock"}
+	local _stime
+	local _etime
+	local _timeout=20
+	__dlog "[INFO] Waiting for docker to initialize..."
+	_stime=$(date +%s)
+	_etime=$(date +%s)
+	until DOCKER_HOST=${_docker_host} docker info >/dev/null 2>&1; do
+		# shellcheck disable=SC2003
+		# shellcheck disable=SC2006
+		# Bitbake requires this syntax
+		if [ "`expr "$_etime" - "$_stime"`" -le ${_timeout} ]; then
+			sleep 1
+			_etime=$(date +%s)
+		else
+			>&2 echo "[ERROR] Timeout while waiting for docker to come up."
+			exit 1
+		fi
+	done
+	__dlog "[INFO] Docker was initialized."
 }

--- a/automation/include/balena-docker.inc
+++ b/automation/include/balena-docker.inc
@@ -62,20 +62,21 @@ balena_docker_start() {
 balena_docker_stop() {
 	local _fail="${1:-"noexit"}"
 	local _pid_file=${2:-"/var/run/docker.pid"}
-	local _timeout=${3:-20}
+	local _pname=${3:-"docker"}
+	local _timeout=${4:-20}
 	local _stime
 	local _etime
 
 	__dlog "[INFO] Running balena_docker_stop..."
 
 	# Stop docker gracefully
-	__dlog "[INFO] Stopping in container docker..."
-	if [ -f "${_pid_file}" ] && [ -s "${_pid_file}" ] && ps "$(cat "${_pid_file}")" | grep -q docker; then
+	__dlog "[INFO] Stopping in container ${_pname}..."
+	if [ -f "${_pid_file}" ] && [ -s "${_pid_file}" ] && ps "$(cat "${_pid_file}")" | grep -q "${_pname}"; then
 		kill "$(cat "${_pid_file}")"
 		# Now wait for it to die
 		_stime=$(date +%s)
 		_etime=$(date +%s)
-		while [ -f "${_pid_file}" ] && [ -s "${_pid_file}" ] && ps "$(cat "${_pid_file}")" | grep -q docker; do
+		while [ -f "${_pid_file}" ] && [ -s "${_pid_file}" ] && ps "$(cat "${_pid_file}")" | grep -q "${_pname}"; do
 			# shellcheck disable=SC2003
 			# shellcheck disable=SC2006
 			# Bitbake requires this syntax
@@ -83,12 +84,12 @@ balena_docker_stop() {
 				sleep 1
 				_etime=$(date +%s)
 			else
-				>&2 echo "[ERROR] Timeout while waiting for in container docker to die."
+				>&2 echo "[ERROR] Timeout while waiting for in container ${_pname} to die."
 				exit 1
 			fi
 		done
 	else
-		>&2 echo "[WARN] Can't stop docker container."
+		>&2 echo "[WARN] Can't stop ${_pname}."
 		>&2 echo "[WARN] Your host might have been left with unreleased resources (ex. loop devices)."
 		if [ "${_fail}" = "fail" ]; then
 			exit 1
@@ -107,13 +108,14 @@ balena_docker_stop() {
 #
 balena_docker_wait() {
 	local _docker_host=${1:-"unix:///var/run/docker.sock"}
+	local _pname="${2:-"docker"}"
 	local _stime
 	local _etime
 	local _timeout=20
-	__dlog "[INFO] Waiting for docker to initialize..."
+	__dlog "[INFO] Waiting for ${_pname} to initialize..."
 	_stime=$(date +%s)
 	_etime=$(date +%s)
-	until DOCKER_HOST=${_docker_host} docker info >/dev/null 2>&1; do
+	until DOCKER_HOST=${_docker_host} ${_pname} info >/dev/null 2>&1; do
 		# shellcheck disable=SC2003
 		# shellcheck disable=SC2006
 		# Bitbake requires this syntax
@@ -121,9 +123,9 @@ balena_docker_wait() {
 			sleep 1
 			_etime=$(date +%s)
 		else
-			>&2 echo "[ERROR] Timeout while waiting for docker to come up."
+			>&2 echo "[ERROR] Timeout while waiting for ${_pname} to come up."
 			exit 1
 		fi
 	done
-	__dlog "[INFO] Docker was initialized."
+	__dlog "[INFO] ${_pname} was initialized."
 }

--- a/build/balena-build.sh
+++ b/build/balena-build.sh
@@ -95,7 +95,7 @@ balena_build_run_barys() {
 		exit 1
 	fi
 	[ -z "${SSH_AUTH_SOCK}" ] && echo "No SSH_AUTH_SOCK in environment - private repositories won't be accessible to the builder" && SSH_AUTH_SOCK="/dev/null"
-	${DOCKER} run --rm -t ${__docker_run_args} \
+	${DOCKER} run --rm ${__docker_run_args} \
 		-v "${work_dir}":/yocto/resin-board \
 		-v "${_dl_dir}":/yocto/shared-downloads \
 		-v "${_sstate_dir}":/yocto/shared-sstate \

--- a/build/balena-build.sh
+++ b/build/balena-build.sh
@@ -17,6 +17,7 @@ Usage: ${script_name} [OPTIONS]
     -g Barys extra arguments (optional, for example '-g "-a VARIABLE=value"')
     -a Balena API environment (defaults to "balena-cloud.com")
     -t Balena API token (optional - private apps access)
+    -k Keep local containers (optional - by default container iamges are removed)
     -h Display usage
 EOF
 	exit 0
@@ -53,10 +54,11 @@ balena_build_run_barys() {
 	local _variant="${3}"
 	local _api_env="${4:-"balena-cloud.com"}"
 	local _token="${5}"
-	local _bitbake_args="${6}"
-	local _bitbake_targets="${7}"
-	local _barys_args="${8}"
-	local _docker_run_args="${9:-"--rm"}"
+	local _keep_helpers="${6}"
+	local _bitbake_args="${7}"
+	local _bitbake_targets="${8}"
+	local _barys_args="${9}"
+	local _docker_run_args="${10:-"--rm"}"
 	local _dl_dir
 	local _sstate_dir
 	local _namespace="${NAMESPACE:-"resin"}"
@@ -120,24 +122,27 @@ balena_build_run_barys() {
 		--skip-discontinued \
 		--rm-work
 
-	balena_lib_docker_remove_helper_images "yocto-build-env"
+	if [ "${_keep_helpers}" = "0" ]; then
+		balena_lib_docker_remove_helper_images "yocto-build-env"
+	fi
 }
 
 main() {
 	local _device_type
 	local _api_env
-	local _token
+	local _token="none"
 	local _shared_dir
 	local _variant
 	local _bitbake_args
 	local _bitbake_targets
 	local _barys_args
+	local _keep_helpers=0
 	## Sanity checks
 	if [ ${#} -lt 1 ] ; then
 		usage
 		exit 1
 	else
-		while getopts "hd:a:t:s:v:b:i:g:" c; do
+		while getopts "hd:a:t:s:v:b:i:g:k" c; do
 			case "${c}" in
 				d) _device_type="${OPTARG}";;
 				a) _api_env="${OPTARG}";;
@@ -147,6 +152,7 @@ main() {
 				b) _bitbake_args="${OPTARG}" ;;
 				i) _bitbake_targets="${OPTARG}" ;;
 				g) _barys_args="${OPTARG}" ;;
+				k) _keep_helpers=1 ;;
 				h) usage;;
 				*) usage;exit 1;;
 			esac
@@ -162,7 +168,7 @@ main() {
 		_variant="${_variant:-"${buildFlavor}"}"
 		[ -z "${_variant}" ] && echo "Variant is required" && exit 1
 
-		balena_build_run_barys "${_device_type}" "${_shared_dir}" "${_variant}" "${_api_env}" "${_token}" "${_bitbake_args}" "${_bitbake_targets}" "${_barys_args}"
+		balena_build_run_barys "${_device_type}" "${_shared_dir}" "${_variant}" "${_api_env}" "${_token}" "${_keep_helpers}" "${_bitbake_args}" "${_bitbake_targets}" "${_barys_args}"
 	fi
 }
 

--- a/build/balena-build.sh
+++ b/build/balena-build.sh
@@ -98,7 +98,7 @@ balena_build_run_barys() {
 	fi
 	[ -z "${SSH_AUTH_SOCK}" ] && echo "No SSH_AUTH_SOCK in environment - private repositories won't be accessible to the builder" && SSH_AUTH_SOCK="/dev/null"
 	${DOCKER} run --rm ${__docker_run_args} \
-		-v "${work_dir}":/yocto/resin-board \
+		-v "${work_dir}":/work \
 		-v "${_dl_dir}":/yocto/shared-downloads \
 		-v "${_sstate_dir}":/yocto/shared-sstate \
 		-v "${SSH_AUTH_SOCK}":/tmp/ssh-agent \


### PR DESCRIPTION
This is complementary to the following meta-balena PR:
https://github.com/balena-os/meta-balena/pull/2167/commits

In summary:

- Shortens the installation path in the build containers so that balena-engine socket fits
- Adds hosttools dependencies to build containers
