### PR TITLE
Revert using newer docker in yocto-build-env

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -26,13 +26,13 @@ RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/l
 RUN apt-get update && apt-get install -y dos2unix && rm -rf /var/lib/apt/lists/*
 
 # Install docker
-# https://docs.docker.com/engine/install/ubuntu/
-RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io && rm -rf /var/lib/apt/lists/*
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod && rm -rf /var/lib/apt/lists/*
+ENV DOCKER_VERSION 1.10.1
+ENV DOCKER_SHA256 de4057057acd259ec38b5244a40d806993e2ca219e9869ace133fad0e09cedf2
 VOLUME /var/lib/docker
+RUN wget -q -O /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} && chmod +x /usr/bin/docker \
+    && echo "${DOCKER_SHA256}" /usr/bin/docker | sha256sum -c -
 
 # Install balena-cli
 ENV BALENA_CLI_VERSION 11.35.4
@@ -41,7 +41,7 @@ RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA
   mv balena-cli/* /usr/bin && \
   rm -rf balena-cli.zip balena-cli
 
-COPY include/balena-docker.inc /
+COPY include/balena-docker.inc include/manage-docker.sh /
 COPY entry_scripts/prepare-and-start.sh /
 
 WORKDIR /work

--- a/automation/include/manage-docker.sh
+++ b/automation/include/manage-docker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_TIMEOUT=20 # Wait 20 seconds for docker to start
+
+cleanup() {
+    echo "[INFO] Running cleanup..."
+
+    # Stop docker gracefully
+    echo "[INFO] Stopping in container docker..."
+    DOCKERPIDFILE=/var/run/docker.pid
+    if [ -f $DOCKERPIDFILE ] && [ -s $DOCKERPIDFILE ] && ps $(cat $DOCKERPIDFILE) | grep -q docker; then
+        kill $(cat $DOCKERPIDFILE)
+        # Now wait for it to die
+        STARTTIME=$(date +%s)
+        ENDTIME=$(date +%s)
+        while [ -f $DOCKERPIDFILE ] && [ -s $DOCKERPIDFILE ] && ps $(cat $DOCKERPIDFILE) | grep -q docker; do
+            if [ $(($ENDTIME - $STARTTIME)) -le $DOCKER_TIMEOUT ]; then
+                sleep 1
+                ENDTIME=$(date +%s)
+            else
+                echo "[ERROR] Timeout while waiting for in container docker to die."
+                exit 1
+            fi
+        done
+    else
+        echo "[WARN] Can't stop docker container."
+        echo "[WARN] Your host might have been left with unreleased resources (ex. loop devices)."
+    fi
+
+    if [ "$1" == "fail" ]; then
+        exit 1
+    fi
+}
+
+wait_docker() {
+  echo "[INFO] Waiting for docker to initialize..."
+  STARTTIME=$(date +%s)
+  ENDTIME=$(date +%s)
+  until docker info >/dev/null 2>&1; do
+      if [ $(($ENDTIME - $STARTTIME)) -le $DOCKER_TIMEOUT ]; then
+          sleep 1
+          ENDTIME=$(date +%s)
+      else
+          echo "[ERROR] Timeout while waiting for docker to come up."
+          exit 1
+      fi
+  done
+  echo "[INFO] Docker was initialized."
+}


### PR DESCRIPTION
Updating the `yocto-build-env` from v1.10.1 to the distribution
supported docker results in random networking errors on the dind
container, with errors like:

fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
^[[91mERROR: http://dl-cdn.alpinelinux.org/alpine/v3.12/main: temporary error (try again later)
WARNING: Ignoring APKINDEX.2c4ac24e.tar.gz: No such file or directory

In the mid-term we will remove the build system dependency on docker by
using a rootless balena-engine on the build process, however as rootless
docker is not supported in aufs for the time being we revert to using
the old docker version.

Once meta-balena is updated to use rootless balena-engine and aufs is
oficially deprecated this commit can be reverted and the docker host
tool dependency removed.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>