### PR TITLE
Rebrand resin to balena and use release_version to specify supervisor

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -18,8 +18,8 @@ print_help() {
 	\t\t --meta-balena-branch\n\
 	\t\t\t (optional) The meta-balena branch to checkout before building.\n\
 \t\t\t\t Default value is __ignore__ which means it builds the meta-balena revision as configured in the git submodule.\n
-	\t\t --supervisor-tag\n\
-	\t\t\t (optional) The resin supervisor tag specifying which supervisor version is to be included in the build.\n\
+	\t\t --supervisor-version\n\
+	\t\t\t (optional) The balena supervisor release version to be included in the build.\n\
 \t\t\t\t Default value is __ignore__ which means use the supervisor version already included in the meta-balena submodule.\n
 	\t\t --preserve-build\n\
 	\t\t\t (optional) Do not delete existing build directory.\n\
@@ -93,12 +93,12 @@ while [[ $# -ge 1 ]]; do
 			fi
 			metaResinBranch="${metaResinBranch:-$2}"
 			;;
-		--supervisor-tag)
+		--supervisor-version)
 			if [ -z "$2" ]; then
-				echo "--supervisor-tag argument needs a resin supervisor tag name (if this option is not used, the default value is __ignore__)"
+				echo "--supervisor-version argument needs a balena supervisor release version (if this option is not used, the default value is __ignore__)"
 				exit 1
 			fi
-			supervisorTag="${supervisorTag:-$2}"
+			supervisorVersion="${supervisorVersion:-$2}"
 			;;
 		--esr)
 			ESR="true"
@@ -115,7 +115,7 @@ while [[ $# -ge 1 ]]; do
 done
 
 metaResinBranch=${metaResinBranch:-__ignore__}
-supervisorTag=${supervisorTag:-__ignore__}
+supervisorVersion=${supervisorVersion:-__ignore__}
 
 # Sanity checks
 if [ -z "$MACHINE" ] || [ -z "$JENKINS_PERSISTENT_WORKDIR" ] || [ -z "$buildFlavor" ]; then
@@ -136,9 +136,9 @@ else
 	exit 1
 fi
 
-# When supervisorTag is provided, set the appropiate barys argument
-if [ "$supervisorTag" != "__ignore__" ]; then
-	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --supervisor-tag $supervisorTag"
+# When supervisorVersion is provided, set the appropiate barys argument
+if [ "$supervisorVersion" != "__ignore__" ]; then
+	BARYS_ARGUMENTS_VAR="$BARYS_ARGUMENTS_VAR --supervisor-version $supervisorVersion"
 fi
 
 # Checkout meta-balena

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -91,7 +91,7 @@ while [[ $# -ge 1 ]]; do
 				echo "--meta-balena-branch argument needs a meta-balena branch name (if this option is not used, the default value is __ignore__)"
 				exit 1
 			fi
-			metaResinBranch="${metaResinBranch:-$2}"
+			metaBalenaBranch="${metaBalenaBranch:-$2}"
 			;;
 		--supervisor-version)
 			if [ -z "$2" ]; then
@@ -114,7 +114,7 @@ while [[ $# -ge 1 ]]; do
 	shift
 done
 
-metaResinBranch=${metaResinBranch:-__ignore__}
+metaBalenaBranch=${metaBalenaBranch:-__ignore__}
 supervisorVersion=${supervisorVersion:-__ignore__}
 
 # Sanity checks
@@ -142,14 +142,14 @@ if [ "$supervisorVersion" != "__ignore__" ]; then
 fi
 
 # Checkout meta-balena
-if [ "$metaResinBranch" = "__ignore__" ]; then
+if [ "$metaBalenaBranch" = "__ignore__" ]; then
 	echo "[INFO] Using the default meta-balena revision (as configured in submodules)."
 else
 	echo "[INFO] Using special meta-balena revision from build params."
 	pushd $WORKSPACE/layers/meta-balena > /dev/null 2>&1
 	git config --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pr/*'
 	git fetch --all
-	git checkout --force $metaResinBranch
+	git checkout --force $metaBalenaBranch
 	popd > /dev/null 2>&1
 fi
 

--- a/build/barys
+++ b/build/barys
@@ -22,7 +22,7 @@ BUILD_DIR=build
 REMOVEBUILD=no
 COMPRESS=no
 DEVELOPMENT_IMAGE=no
-SUPERVISOR_TAG=
+SUPERVISOR_VERSION=
 SHARED_DOWNLOADS=
 SHARED_SSTATE=
 DRY_RUN=no
@@ -75,8 +75,8 @@ function help {
     echo -e "\t\t The format of the arguments need to be VARIABLE=VALUE ."
     echo -e "\t\t VALUE doesn't support white spaces."
 
-    echo -e "\t--supervisor-tag"
-    echo -e "\t\t Use a specific supervisor tag."
+    echo -e "\t--supervisor-version"
+    echo -e "\t\t Use a specific supervisor release version."
     echo -e "\t\t Default: production."
 
     echo -e "\t-r | --remove-build"
@@ -257,11 +257,11 @@ while [[ $# -ge 1 ]]; do
 	    done
 	    shift $_cnt
             ;;
-        --supervisor-tag)
+        --supervisor-version)
             if [ -z "$2" ]; then
                 log ERROR "\"$1\" argument needs a value."
             fi
-            SUPERVISOR_TAG=$2
+            SUPERVISOR_VERSION=$2
             shift
             ;;
         -r|--remove-build)
@@ -340,9 +340,9 @@ while [[ $# -ge 1 ]]; do
                 [Yy]* ) DEVELOPMENT_IMAGE=yes;;
             esac
 
-            read -p "Supervisor version? [$SUPERVISOR_TAG] " yn
+            read -p "Supervisor version? [$SUPERVISOR_VERSION] " yn
             if [ -n "$yn" ]; then
-                SUPERVISOR_TAG=$yn
+                SUPERVISOR_VERSION=$yn
             fi
 
             read -p "Remove build directory? yes/[no] " yn
@@ -423,7 +423,7 @@ if [ "z$LOG" == "zyes" ]; then
     echo "Shared downloads directory: $SHARED_DOWNLOADS" >> $LOGFILE
     echo "Shared sstate directory: $SHARED_SSTATE" >> $LOGFILE
     echo "Development image? $DEVELOPMENT_IMAGE" >> $LOGFILE
-    echo "Forced supervisor image tag: $SUPERVISOR_TAG" >> $LOGFILE
+    echo "Forced supervisor image release version: $SUPERVISOR_VERSION" >> $LOGFILE
     echo "Inherit rm_work? $RM_WORK" >> $LOGFILE
     echo "Enable build history? $BUILD_HISTORY" >> $LOGFILE
     echo "================"`basename "$0"`" HEADER STOP=====================" >> $LOGFILE
@@ -462,10 +462,10 @@ fi
 if [ -n "$SHARED_SSTATE" ]; then
     sed -i "s#.*SSTATE_DIR ?=.*#SSTATE_DIR ?= \"$SHARED_SSTATE\"#g" conf/local.conf
 fi
-if [ -n "$SUPERVISOR_TAG" ]; then
-    grep -q 'SUPERVISOR_TAG ?=' conf/local.conf \
-    && sed -i "s/.*SUPERVISOR_TAG ?=.*/SUPERVISOR_TAG ?= \"$SUPERVISOR_TAG\"/g" conf/local.conf \
-    || echo "SUPERVISOR_TAG ?= $SUPERVISOR_TAG" >> conf/local.conf
+if [ -n "$SUPERVISOR_VERSION" ]; then
+    grep -q 'SUPERVISOR_VERSION ?=' conf/local.conf \
+    && sed -i "s/.*SUPERVISOR_VERSION ?=.*/SUPERVISOR_VERSION ?= \"$SUPERVISOR_VERSION\"/g" conf/local.conf \
+    || echo 'SUPERVISOR_VERSION ?= "'"${SUPERVISOR_VERSION}"'"' >> conf/local.conf
 fi
 
 perl -i -pe 'BEGIN {$/ = undef}; s/^\n# Barys: Additional variables.*//sm' conf/local.conf


### PR DESCRIPTION
* Barys and `jenkins_build.sh` argument `--supervisor-tag` becomes `--supervisor-release` in preparation for the OS to use `release_version` to fetch the supervisor image
* Build jobs needs to change the configuration variable `supervisorTag` with `supervisorRelease`
* Build jobs needs to change `metaResinBranch` to `metaBalenaBranch`