### PR TITLE
Add hostos blocks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository provides helper scripts and tools for building Balena OS.
 
+* __build/barys__: Used for native builds, barys is a wrapper script over bitbake that builds BalenaOS. Used to initialize a build directory and create device type json files out of the coffeescript files, and then run the default build. Use `-n` to just setup the build directory.
+* __build/balena-build.sh__: Used to build in a container, this script downloads a container builder image and calls barys.
+* __automation/jenkins_build.sh__: Used in jenkins automation to build the OS, requires a jenkins environment to work.
+* __automation/jenkins_build-blocks.sh__: Used in jenkins automation to build OS blocks defined in a hostOS contract, requires a jenkins environment to work.
+
 ## Contributing
 
 ### Issues

--- a/automation/Dockerfile_yocto-block-build-env
+++ b/automation/Dockerfile_yocto-block-build-env
@@ -1,0 +1,20 @@
+ARG NAMESPACE="resin"
+ARG TAG="latest"
+FROM ${NAMESPACE}/balena-push-env:${TAG}
+
+RUN apt-get update && apt-get install -y git make automake gcc libtool libtool-bin pkg-config libarchive-dev libcurl4-openssl-dev libssl-dev libgpgme11-dev && rm -rf /var/lib/apt/lists/*
+
+RUN git clone git://git.yoctoproject.org/opkg opkg
+RUN cd ./opkg && ./autogen.sh && ./configure --enable-libsolv  && make && make install
+
+RUN LD_LIBRARY_PATH=/usr/local/lib && ldconfig
+
+RUN mkdir -p /var/lib/opkg /etc/opkg/
+RUN echo 'dest hostapp /hostapp\n\
+option info_dir /var/lib/opkg/info\n\
+option lists_dir /var/lib/opkg/lists\n\
+option status_file /var/lib/opkg/status'\
+> /etc/opkg/opkg.conf
+
+COPY include/balena-api.inc include/balena-lib.inc entry_scripts/balena-build-block.sh /
+WORKDIR /

--- a/automation/entry_scripts/balena-build-block.sh
+++ b/automation/entry_scripts/balena-build-block.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${script_dir}/balena-api.inc"
+source "${script_dir}/balena-lib.inc"
+
+# Input checks
+[ -z "${APPNAME}" ] && echo "The block's app name needs to be defined" && exit 1
+[ -z "${API_ENV}" ] && echo "Balena's environment needs to be defined" && exit 1
+[ -z "${BALENAOS_TOKEN}" ] && echo "Balena's environment token needs to be defined" && exit 1
+[ -z "${MACHINE}" ] && echo "Machine needs to be defined" && exit 1
+[ -z "${PACKAGES}" ] && echo "list of packages to install without dependencies" && exit 1
+[ -z "${RELEASE_VERSION}" ] && echo "A release version needs to be defined" && exit 1
+[ -z "${WORKSPACE}" ] && echo "Workspace needs to be defined" && exit 1
+
+[ -z "${PACKAGE_TYPE}" ] && PACKAGE_TYPE="ipk"
+[ -z "${BALENAOS_ACCOUNT}" ] && BALENAOS_ACCOUNT="balena_os"
+
+DEVICE_TYPE_JSON="$WORKSPACE/$MACHINE.json"
+if [ -e "${DEVICE_TYPE_JSON}" ]; then
+	ARCH=$(jq --raw-output '.arch' "$DEVICE_TYPE_JSON")
+fi
+[ -z "${ARCH}" ] && echo "Device architecture is required" && exit 1
+
+source /balena-docker.inc
+
+finish() {
+	balena_docker_stop
+	# Dockerd leaves a mount here
+	if ! umount "${DOCKER_ROOT}"; then
+		umount -l "${DOCKER_ROOT}" || true
+	fi
+	rm -rf "${TMPDIR}"
+}
+trap finish EXIT ERR
+
+# Start docker
+# Data root needs to be on a non-aufs directory to use balena build
+TMPDIR=$(mktemp -d --tmpdir="${WORKSPACE:?}")
+DOCKER_ROOT="${TMPDIR}/docker"
+balena_docker_start "${DOCKER_ROOT}" "/var/run" "/var/log/docker.log"
+balena_docker_wait
+
+# Only support overlay images for the time being. Labels to be parametrized from contract in future.
+cat << 'EOF' > ${TMPDIR}/Dockerfile
+ARG NAMESPACE=resin
+ARG TAG=latest
+FROM ${NAMESPACE}/yocto-block-build-env:${TAG} AS builder
+ARG PACKAGES
+ARG ARCH_LIST
+ARG FEED_URL="file:/ipk"
+COPY feed /
+RUN priority=1; for arch in $ARCH_LIST; do echo "arch $arch $priority" >> /etc/opkg/opkg.conf; priority=$(expr $priority + 5); echo "src/gz balena-$arch $FEED_URL/$arch" >> /etc/opkg/opkg.conf; done
+RUN mkdir /hostapp
+RUN opkg -f /etc/opkg/opkg.conf update && opkg -f /etc/opkg/opkg.conf --nodeps --dest=hostapp install ${PACKAGES} || true
+RUN rm -rf /hostapp/var/lib/opkg
+FROM scratch
+COPY --from=builder /hostapp /
+EOF
+
+# Add image labels
+echo "LABEL ${BALENA_HOSTOS_BLOCK_CLASS}=overlay" >> "${TMPDIR}/Dockerfile"
+echo "LABEL ${BALENA_HOSTOS_BLOCK_REQUIRES_REBOOT}=1"  >> "${TMPDIR}/Dockerfile"
+echo "LABEL ${BALENA_HOSTOS_BLOCK_STORE}=data" >> "${TMPDIR}/Dockerfile"
+
+# Copy local package feed to context if available from previous build step
+if [ -d "${WORKSPACE}/deploy-jenkins/${PACKAGE_TYPE}" ]; then
+	ARCH_LIST=""
+	mkdir -p "${TMPDIR}/feed"
+	cp -r "${WORKSPACE}/deploy-jenkins/${PACKAGE_TYPE}" "${TMPDIR}/feed/"
+	# Extract package architecture list from feed
+	# Each architecture is one directory
+	while IFS=$'\n' read -r dir; do
+		if [ -z "${ARCH_LIST}" ]; then
+			ARCH_LIST="${dir}"
+		else
+			ARCH_LIST="${ARCH_LIST} ${dir}"
+		fi
+	done< <(find "${WORKSPACE}/deploy-jenkins/${PACKAGE_TYPE}" -mindepth 1 -maxdepth 1 -type d | xargs -I{} basename {})
+else
+	proto=${FEED_URL%:*}
+	if [ -z "${FEED_URL}" ] || [ "${proto}" = "file" ]; then
+		echo "[ERROR] Local package feed not available"
+		exit 1
+	fi
+fi
+
+BALENAOS_ACCOUNT="${BALENAOS_ACCOUNT:-"balena_os"}"
+
+echo "[INFO] Logging into $API_ENV as ${BALENAOS_ACCOUNT}"
+export BALENARC_BALENA_URL=${API_ENV}
+balena login --token "${BALENAOS_TOKEN}"
+
+pushd "${TMPDIR}"
+balena_api_create_public_app "${APPNAME}" "${API_ENV}" "${MACHINE}" "${balenaCloudEmail}" "${balenaCloudPassword}"
+
+# Clean local docker of labelled hostos images
+docker rmi -f $(docker images --filter "label=${BALENA_HOSTOS_BLOCK_CLASS}" --format "{{.ID}}" | tr '\n' ' ') 2> /dev/null || true
+
+if balena build --logs --nocache --deviceType "${MACHINE}" --arch "${ARCH}" --buildArg PACKAGES="${PACKAGES}" --buildArg ARCH_LIST="${ARCH_LIST}" --buildArg NAMESPACE="${NAMESPACE:-resin}"; then
+	image_id=$(docker images --filter "label=${BALENA_HOSTOS_BLOCK_CLASS}" --format "{{.ID}}")
+	mkdir -p "${WORKSPACE}/deploy-jenkins"
+	docker save "${image_id}" > "${WORKSPACE}/deploy-jenkins/${APPNAME}-${RELEASE_VERSION}.docker"
+	_releaseID=$(balena deploy "${BALENAOS_ACCOUNT}/${APPNAME}" "${image_id}" | sed -n 's/.*Release: //p')
+	balena_api_set_release_version "${_releaseID}" "${API_ENV}" "${BALENAOS_TOKEN}" "${RELEASE_VERSION}"
+else
+	echo "[ERROR] Fail to build"
+	exit 1
+fi
+
+popd
+
+exit 0

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -6,6 +6,7 @@ device_dir=$( if cat /proc/self/cgroup | grep -q docker; then if [ -d "/work" ];
 
 source "${include_dir}/balena-api.inc"
 source "${include_dir}/balena-lib.inc"
+source "${include_dir}/balena-docker.inc"
 
 # Deploys to passed container image to BalenaCloud
 # Input arguments:
@@ -353,4 +354,275 @@ else
 fi
 EOSU
 		'
+}
+
+# Builds and deploys the specified block to BalenaCloud
+# Input arguments;
+#  $1: App name to deploy into
+#  $2: Path to the image to deploy
+#  $3: Device type for the app
+#  $4: BalenaCloud email address (defaults to the balenaCloudEmail enviromental variable)
+#  $5: BalenaCloud password (defaults to the balenaCloudPassword enviromental variable)
+#
+balena_deploy_block() {
+	local _appName="$1"
+	local _image_path="${2}"
+	local _device_type="${3:-${MACHINE}}"
+	local _bootable=${4:-"0"}
+	local _balenaos_account="${5:-"balena_os"}"
+	local _balenaCloudEmail="${6:-"${balenaCloudEmail}"}"
+	local _balenaCloudPassword="${7:-"${balenaCloudPassword}"}"
+
+	[ -z "${_appName}" ] && echo "App name is required" && return
+	[ -z "${_image_path}" ] && echo "Image path is required" && return
+	[ -z "${_device_type}" ] && echo "Device type is required" && return
+
+	NAMESPACE=${NAMESPACE:-resin}
+	if ! balena_lib_docker_pull_helper_image "Dockerfile_balena-push-env" balena_yocto_scripts_revision; then
+		return 1
+	fi
+	docker run --rm -t \
+		-e APPNAME="${_appName}" \
+		-e API_ENV="$(balena_lib_environment)" \
+		-e BALENAOS_TOKEN="$(balena_lib_token "${API_ENV}")" \
+		-e BALENAOS_ACCOUNT="${_balenaos_account}" \
+		-e RELEASE_VERSION="$(balena_lib_get_os_version)" \
+		-e MACHINE="${_device_type}" \
+		-e BOOTABLE="${_bootable}" \
+		-e balenaCloudEmail="${_balenaCloudEmail}" \
+		-e balenaCloudPassword="${_balenaCloudPassword}" \
+		-v "${_image_path}":/host/appimage.docker \
+		--privileged \
+		"${NAMESPACE}"/balena-push-env:"${balena_yocto_scripts_revision}" /balena-deploy-block.sh
+
+	balena_lib_docker_remove_helper_images "balena-push-env"
+}
+
+# Builds and deploys the specified block to BalenaCloud
+# Input arguments;
+#  $1: App name to deploy into
+#  $2: Device type for the app
+#  $3: Package list to build the block with
+#  $4: Balena cloud account (defaults to balena_os)
+#  $5: Balena API environment
+#
+balena_deploy_build_block() {
+	local _appName="$1"
+	local _device_type="${2:-${MACHINE}}"
+	local _packages="${3:-${PACKAGES}}"
+	local _balenaos_account="${4:-balena_os}"
+	local _api_env="${5:-$(balena_lib_environment)}"
+
+	[ -z "${_appName}" ] && echo "App name is required" && return
+	[ -z "${_device_type}" ] && echo "Device type is required" && return
+	[ -z "${_packages}" ] && echo "Package list is required" && return
+
+	if ! balena_lib_docker_pull_helper_image "Dockerfile_yocto-block-build-env" balena_yocto_scripts_revision; then
+		return 1
+	fi
+	docker run --rm -t \
+		-e APPNAME="${_appName}" \
+		-e API_ENV="${_api_env}" \
+		-e BALENAOS_TOKEN="$(balena_lib_token "${API_ENV}")" \
+		-e NAMESPACE="${NAMESPACE:-resin}" \
+		-e BALENAOS_ACCOUNT="${_balenaos_account}" \
+		-e RELEASE_VERSION="$(balena_lib_get_os_version)" \
+		-e PACKAGES="${_packages}" \
+		-e MACHINE="${_device_type}" \
+		-e TAG="${balena_yocto_scripts_revision}" \
+		-e WORKSPACE=/yocto/resin-board \
+		-e balenaCloudEmail="${balenaCloudEmail}" \
+		-e balenaCloudPassword="${balenaCloudPassword}" \
+		-v "${WORKSPACE:-"${PWD}"}":/yocto/resin-board \
+		--privileged \
+		"${NAMESPACE}"/yocto-block-build-env:"${balena_yocto_scripts_revision}" /balena-build-block.sh
+
+	balena_lib_docker_remove_helper_images "yocto-block-build-env"
+}
+
+# Initialize a compose file in the specified path
+#
+# Input:
+# $1: Path to create the compose file into
+__init_compose() {
+	local _path="${1}"
+	[ -z "${_path}" ] && return
+	cat << EOF > "${_path}/docker-compose.yml"
+version: '2'
+services:
+EOF
+}
+
+# Deploy a package feed locally
+#
+# Inputs:
+#
+# $1: Directory to deploy to
+# $2: Package type (defaults to ipk)
+#
+# Output
+#
+# 0 on success or 1 on failure
+#
+balena_deploy_feed() {
+	local _deploy_dir="${1}"
+	local _package_type="${2}"
+
+	[ -z "${_deploy_dir}" ] && >&2 echo "Deploy directory is required" && return 1
+
+	_package_type="${_package_type:-"ipk"}"
+	if [ -e "${device_dir}/build/tmp/deploy/${_package_type}" ]; then
+		echo "[INFO]: Deploying package feed"
+		mkdir -p "$_deploy_dir/${_package_type}"
+		cp -r "${device_dir}/build/tmp/deploy/${_package_type}" "$_deploy_dir/"
+	fi
+}
+
+# Add a compose service
+#
+# Inputs:
+# $1: Path to the directory holding the compose file - will be created if needed
+# $2: Name of the service to be added
+# $3: Image digest for the service
+# $4: Image class: fileset, overlay or service (default)
+# $5: Image reboot required: 0 (default) or 1
+# $6: Image engine type: boot, root or data (default)
+# $6: Image is bootable, false (default) or true
+#
+# Outputs:
+#    Compose file in the specified path
+#
+__add_compose_service() {
+	local _path=$1
+	local _service_name=$2
+	local _image=$3
+	local _image_class=$4
+	local _image_reboot=$5
+	local _image_engine=$6
+	local _bootable=$7
+
+	[ -z "${_path}" ] || [ -z "${_service_name}" ] || [ -z "${_image}" ] && return
+	_image_class=${_image_class:-"service"}
+	_image_reboot=${_image_reboot:-0}
+	_image_engine=${_image_engine:-"data"}
+	_bootable=${_bootable:-"false"}
+
+	if [ ! -f "${_path}/docker-compose.yml" ]; then
+		__init_compose "${_path}"
+	fi
+	printf "  %s:\n" "${_service_name}" >> "${_path}/docker-compose.yml"
+	printf "    image: %s\n" "${_image}" >> "${_path}/docker-compose.yml"
+	printf "    labels:\n" >> "${_path}/docker-compose.yml"
+	if [ -n "${_image_class}" ]; then
+		printf "      %s: %s\n" \""${BALENA_HOSTOS_BLOCK_CLASS}"\" \""${_image_class}"\" >> "${_path}/docker-compose.yml"
+	fi
+	if [ "${_image_reboot}" = "1" ]; then
+		printf "      %s: '1'\n" \""${BALENA_HOSTOS_BLOCK_REQUIRES_REBOOT}"\" >> "${_path}/docker-compose.yml"
+	fi
+	if [ -n "${_image_engine}" ]; then
+		printf "      %s: %s\n" \""${BALENA_HOSTOS_BLOCK_STORE}"\" \""${_image_engine}"\" >> "${_path}/docker-compose.yml"
+	fi
+	if [ "${_bootable}" = "true" ]; then
+		printf "      %s: %s\n" \""${BALENA_HOSTOS_BLOCK_BOOTABLE}"\" \""${_bootable}"\" >> "${_path}/docker-compose.yml"
+	fi
+}
+
+# Creates a compose file
+#
+# Inputs:
+# $1: Device type to build for
+# $2: Balena API environment (default to balena-cloud.com)
+# $3: BalenaOS version - defaults to current device repository tag
+# $4: BalenaOS token
+# $5: HostOS blocks - default to none
+#
+# Outputs:
+#    Path where the compose file is created
+#
+__create_compose_file() {
+	local _device_type="$1"
+	local _apiEnv="$2"
+	local _version="$3"
+	local _token="$4"
+	local _blocks="$5"
+	local _path
+	local _block_image
+	local _class
+	local _store
+	local _reboot_required
+	local _block
+	local _image_id
+	local _bootable
+
+	[ -z "${_device_type}" ] && return
+	_version=${version:-$(balena_lib_get_os_version)}
+	_apiEnv=${_apiEnv:-"balena-cloud.com"}
+	[ -z "${_path}" ] && _path=$(mktemp -d)
+
+	[ -z "${_blocks}" ] && >&2 echo "Blocks are required" && return 1
+	for _block in ${_blocks}; do
+		_block_image=$(balena_api_fetch_image_from_app "${_block}" "${_version}" "${_apiEnv}")
+		_image_id=$(balena_docker_image_retrieve "${_block_image}")
+		if [ -z "${_block_image}" ] || [ "${_block_image}" = "" ]; then
+			>&2 echo "[${_block}] No such image for ${_version} in ${_apiEnv}"
+			continue
+		fi
+		_class=$(balena_lib_get_label_from_image "${_image_id}" "${BALENA_HOSTOS_BLOCK_CLASS}")
+		_store=$(balena_lib_get_label_from_image "${_image_id}" "${BALENA_HOSTOS_BLOCK_STORE}")
+		_reboot_required=$(balena_lib_get_label_from_image "${_image_id}" "${BALENA_HOSTOS_BLOCK_REQUIRES_REBOOT}")
+		_bootable=$(balena_api_is_bootable "${_block}" "${_apiEnv}" "${_token}")
+		__add_compose_service "${_path}" "${_block}" "${_block_image}" "${_class}" "${_reboot_required}" "${_store}" "${_bootable}"
+	done
+	echo "${_path}"
+}
+
+# Deploys a multi-container hostOS
+#
+# Inputs:
+# $1: Application name
+# $2: HostOS blocks - required
+# $3: Device type for the application
+# $4: Balena API environment (default to balena-cloud.com)
+# $5: Balena API token (defaults to ~/.balena/token)
+# $6: Balena cloud account (defaults to balena_os)
+# $7: Bootable 0 or 1 (default)
+#
+# Outputs:
+#    None
+#
+balena_deploy_hostos() {
+	local _appName="$1"
+	local _blocks="$2"
+	local _device_type="$3"
+	local _apiEnv="$4"
+	local _token="$5"
+	local _account="$6"
+	local _bootable="${7:-1}"
+	local _path
+
+	_apiEnv=${_apiEnv:-"$(balena_lib_environment)"}
+	_account=${_account:-"balena_os"}
+	_token=${_token:-"$(balena_lib_token "${_apiEnv}")"}
+	_version=$(balena_lib_get_os_version)
+	[ -z "${_version}" ] && >&2 echo "Invalid version" && return
+	[ -z "${_device_type}" ] && >&2 echo "Required device type" && return
+	_path=$(__create_compose_file "${_device_type}" "${_apiEnv}" "${_version}" "${_token}" "${_blocks}")
+	if [ -n "${balenaCloudEmail}" ] && [ -n "${balenaCloudPassword}" ]; then
+		balena_api_create_public_app "${_appName}" "${_apiEnv}" "${_device_type}" "${balenaCloudEmail}" "${balenaCloudPassword}" "${_bootable}"
+	else
+		>&2 echo "Balena credentials need to be available in the environment to create public apps"
+	fi
+
+	if balena_api_get_release "${_appName}" "${_version}" "${_apiEnv}"; then
+		>&2 echo "[INFO] Release ${_version} already exists for ${_appName}"
+		return
+	fi
+	balena_lib_login "${_apiEnv}" "${_token}"
+	if [ ! -f "${_path}/docker-compose.yml" ]; then
+		>&2 echo "No compose file in ${_path}"
+		return
+	fi
+	_releaseID=$(BALENARC_BALENA_URL="${_apiEnv}" balena deploy "${_appName}" --build --source "${_path}" | sed -n 's/.*Release: //p')
+	echo "${_releaseID} deployed to ${_appName}"
+	balena_api_set_release_version "${_releaseID}" "${_apiEnv}" "${_token}" "${_version}"
 }

--- a/automation/jenkins_build-blocks.sh
+++ b/automation/jenkins_build-blocks.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -e
+
+script_name=$(basename "${0}")
+automation_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+include_dir="${automation_dir}/include"
+build_dir="${automation_dir}/../build"
+work_dir=$( cd "${automation_dir}/../../" && pwd )
+
+usage() {
+	cat <<EOF
+Usage: ${script_name} [OPTIONS]
+    -d Device type name
+    -a Balena API environment
+    -b HostOS block names
+    -t Balena API token
+    -n Registry namespace
+    -s Shared build directory
+    -v BalenaOS variant (dev | prod)
+    -c Balena account (defaults to balena_os)
+    -h Display usage
+EOF
+	exit 0
+}
+
+source "${include_dir}/balena-api.inc"
+source "${include_dir}/balena-lib.inc"
+source "${include_dir}/balena-deploy.inc"
+
+__build_hostos_blocks() {
+	local _device_type="${1}"
+	local _shared_dir="${2}"
+	local _blocks="${3}"
+	local _api_env="${4}"
+	local _balenaos_account="${5}"
+	local _hostos_blocks=""
+	local _appname
+	local _appnames
+	local _release_version
+	local _packages
+	local _bitbake_targets
+	local _package_type="${PACKAGE_TYPE:-"ipk"}"
+
+	_api_env="${_api_env:-$(balena_lib_environment)}"
+
+	echo "[INFO] Building ${_device_type} with shared dir ${_shared_dir}"
+	if [ -n "${_blocks}" ]; then
+		_blocks=$(echo ${_blocks} | tr ":" " ")
+		echo "[INFO] Building with the following hostOS block images: ${_blocks}"
+		for _block in ${_blocks}; do
+			_appname="${_device_type}-${_block}"
+			if [ -z "${_appnames}" ]; then
+				_appnames="${_appname}"
+			else
+				_appnames="${_appnames} ${_appname}"
+			fi
+			_release_version=$(balena_lib_get_os_version)
+			if balena_api_get_release "${_device_type}-${_block}" "${_release_version}" "${_api_env}"; then
+				echo "[INFO] Release ${_release_version} already exists for ${_block}"
+				continue
+			fi
+			_packages=$(balena_lib_fetch_package_list "${_block}" "${_device_type}")
+			if [ "$?" -ne 0 ] || [ -z "${_packages}" ]; then
+				echo "No packages found in contract"
+				exit 1
+			fi
+			_bitbake_targets="${_bitbake_targets} ${_packages}"
+		done
+		_hostos_blocks="--additional-variable HOSTOS_BLOCKS=${appnames}"
+
+		if [ -n "${_bitbake_targets}" ]; then
+			_bitbake_targets="${_bitbake_targets} os-release package-index"
+			"${build_dir}"/balena-build.sh -d "${_device_type}" -a "${_api_env}" -b "-k" -s "${_shared_dir}" -v "${_variant}"  -i "${_bitbake_targets}"
+
+			# Deploy package feed
+			local _deploy_dir="${work_dir}/deploy-jenkins/"
+			mkdir -p "${_deploy_dir}"
+			balena_deploy_feed "${_deploy_dir}"
+
+			for _block in ${_blocks}; do
+				_appname="${_device_type}-${_block}"
+				balena_deploy_build_block "${_appname}" "${_device_type}" "${_packages}" "${_balenaos_account}" "${_api_env}"
+			done
+
+			# Remove packages folder from deploy directory
+			rm -rf "${_deploy_dir}/${_package_type}"
+		fi
+		echo "${_hostos_blocks}"
+	fi
+}
+
+
+main() {
+	local _device_type
+	local _api_env
+	local _token
+	local _namespace
+	local _shared_dir
+	local _hostos_blocks
+	local _balenaos_account
+	local _esr=0
+	## Sanity checks
+	if [ ${#} -lt 1 ] ; then
+		usage
+		exit 1
+	else
+		while getopts "hd:a:t:n:s:b:v:c:e" c; do
+			case "${c}" in
+				d) _device_type="${OPTARG}";;
+				a) _api_env="${OPTARG}";;
+				b) _blocks="${OPTARG}";;
+				t) _token="${OPTARG}";;
+				n) _namespace="${OPTARG}" ;;
+				s) _shared_dir="${OPTARG}" ;;
+				v) _variant="${OPTARG}" ;;
+				c) _balenaos_account="${OPTARG}" ;;
+				e) _esr=1 ;;
+				h) usage;;
+				*) usage;exit 1;;
+			esac
+		done
+
+		_device_type="${_device_type:-"${MACHINE}"}"
+		[ -z "${_device_type}" ] && echo "Device type is required" && exit 1
+
+		_api_env="${_api_env:-$(balena_lib_environment)}"
+		_token="${_token:-$(balena_lib_token "${_api_env}")}"
+		_shared_dir="${_shared_dir:-"${YOCTO_DIR}"}"
+		[ -z "${_shared_dir}" ] && echo "Shared directory is required" && exit 1
+		_blocks="${_blocks:-"${hostOSBlocks}"}"
+		[ -z "${_blocks}" ] && echo "No block names provided - nothing to do" && exit 1
+		[ -n "${_namespace}" ] && echo "Setting dockerhub account to ${_namespace}" && export NAMESPACE=${_namespace}
+		_balenaos_account=${_balenaos_account:-balena_os}
+
+		_hostos_blocks=$(__build_hostos_blocks "${_device_type}" "${_shared_dir}" "${_blocks}" "${_api_env}" "${_balenaos_account}")
+	fi
+}
+
+main "${@}"


### PR DESCRIPTION
* Adds a `jenkins_build-blocks.sh` script to build and deploy package based hostos blocks. These blocks are defined in a contract.
* Extend `balena-deploy` to deploy OS block and hostOS apps.. A hostOS is deployed from a compose file that is automatically generated from the blocks that define the hostOS.
* Update the README to mention the main scripts in the repository.