### PR TITLE
entry_scripts: Fix source path for includes

### DIFF
--- a/automation/entry_scripts/balena-build-block.sh
+++ b/automation/entry_scripts/balena-build-block.sh
@@ -3,8 +3,8 @@
 set -e
 
 script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${script_dir}/balena-api.inc"
-source "${script_dir}/balena-lib.inc"
+source "${script_dir}/../include/balena-api.inc"
+source "${script_dir}/../include/balena-lib.inc"
 
 # Input checks
 [ -z "${APPNAME}" ] && echo "The block's app name needs to be defined" && exit 1

--- a/automation/entry_scripts/balena-deploy-block.sh
+++ b/automation/entry_scripts/balena-deploy-block.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-source /balena-docker.inc
-source /balena-api.inc
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${script_dir}/../include/balena-api.inc"
+source "${script_dir}/../include/balena-lib.inc"
 
 trap 'balena_docker_stop fail' SIGINT SIGTERM
 

--- a/automation/entry_scripts/prepare-and-start.sh
+++ b/automation/entry_scripts/prepare-and-start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-source /balena-docker.inc
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source "${script_dir}/../include/balena-docker.inc"
 
 trap 'balena_docker_stop fail' SIGINT SIGTERM
 


### PR DESCRIPTION
Change the path of the included bash scripts
as jenkins deploys currently fail with:

    balena-api.inc: line 306: balena_lib_resolve_aliases: command not found
    Build step 'Execute shell' marked build as failure

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>