### PR TITLE
balena-deploy: Provide working directory when deploying hostapp

### DIFF
--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -62,6 +62,7 @@ balena_deploy_hostapp() {
 		-e MACHINE="${_device_type}" \
 		-e VERBOSE="${VERBOSE}" \
 		-e balenaCloudEmail="${_balenaCloudEmail}" \
+		-e BOOTABLE="1" \
 		-e balenaCloudPassword="${_balenaCloudPassword}" \
 		-e META_BALENA_VERSION="${_meta_balena_version}" \
 		-v "${_image_path}":/host/appimage.docker \

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -65,6 +65,7 @@ balena_deploy_hostapp() {
 		-e balenaCloudPassword="${_balenaCloudPassword}" \
 		-e META_BALENA_VERSION="${_meta_balena_version}" \
 		-v "${_image_path}":/host/appimage.docker \
+		-v "${device_dir}":/work \
 		--privileged \
 		"${NAMESPACE}"/balena-push-env:"${balena_yocto_scripts_revision}" /balena-deploy-block.sh
 


### PR DESCRIPTION
When creating a public app, the workdir is used to retrieve the URL
used in the public app creation.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>