### PR TITLE
Update balena-cli to 12.50.1 in automation dockerfiles

### DIFF
--- a/automation/Dockerfile_balena-push-env
+++ b/automation/Dockerfile_balena-push-env
@@ -24,7 +24,7 @@ RUN curl -sSL https://download.docker.com/linux/static/edge/x86_64/docker-${DOCK
   && mv /docker/* /usr/local/bin/
 
 # Install balena-cli
-ENV BALENA_CLI_VERSION 11.35.4
+ENV BALENA_CLI_VERSION 12.50.1
 RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA_CLI_VERSION/balena-cli-v$BALENA_CLI_VERSION-linux-x64-standalone.zip > balena-cli.zip && \
   unzip balena-cli.zip && \
   mv balena-cli/* /usr/bin && \

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-c
 VOLUME /var/lib/docker
 
 # Install balena-cli
-ENV BALENA_CLI_VERSION 11.35.4
+ENV BALENA_CLI_VERSION 12.50.1
 RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA_CLI_VERSION/balena-cli-v$BALENA_CLI_VERSION-linux-x64-standalone.zip > balena-cli.zip && \
   unzip balena-cli.zip && \
   mv balena-cli/* /usr/bin && \


### PR DESCRIPTION
This is necessary for AMI preloading to work, additionally it has been more than a year since the last update, we should keep up.