### PR TITLE
balena-deploy: Avoid patching test suites config.js during deploy

### DIFF
--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -107,24 +107,6 @@ balena_deploy_artifacts () {
 		# package all leviathan/testbot tests from meta-balena to the deploy dir
 		# make sure they are compressed so a flattened unzip of artifacts does not fail
 		(cd "${device_dir}/layers/meta-balena/tests" || return
-			if [ -f suites/config.js ]
-			then
-				# substitute the device type slug
-				perl -i~ -0777 -pe "s/deviceType: [^,]+,/deviceType: '${_slug:-$_device_type}',/g" suites/config.js
-				if [[ "${_slug:-$_device_type}" = generic* ]]
-				then
-					# if the device type is generic we need to use localhost workers
-					perl -i~ -0777 -pe "s/workers: ({|\[)[^}\]]+(}|\]),/workers: ['http:\/\/localhost'],/g" suites/config.js
-					perl -i~ -0777 -pe "s/networkWireless: [^,]+,/networkWireless: false,/g" suites/config.js
-				else
-					# otherwise we need to use testbot workers
-					perl -i~ -0777 -pe "s/workers: ({|\[)[^}\]]+(}|\]),/workers: {
-		balenaApplication: process.env.BALENA_CLOUD_APP_NAME,
-		apiKey: process.env.BALENA_CLOUD_API_KEY,
-	},/g" suites/config.js
-					perl -i~ -0777 -pe "s/networkWireless: [^,]+,/networkWireless: true,/g" suites/config.js
-				fi
-			fi
 			tar -czvf "$_deploy_dir/tests.tar.gz" .
 		)
 	fi


### PR DESCRIPTION
This will allow us to make changes to config.js in meta-balena without
breaking the deploy steps. If additional changes are needed at runtime
the substitutions can be made by the leviathan Jenkins job.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/pull/2514