### PR TITLE
jenkins_build: Use recurse-submodules when checking out meta-balena

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -138,7 +138,7 @@ else
 	pushd "$WORKSPACE/layers/meta-balena" > /dev/null 2>&1
 	git config --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pr/*'
 	git fetch --all
-	git checkout --force "$metaBalenaBranch"
+	git checkout --force --recurse-submodule "$metaBalenaBranch"
 	popd > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
If meta-balena has submodule updates we want to make sure to use them.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/pull/2514