### PR TITLE
Init and update submodules when switching meta-balena branches

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -138,7 +138,8 @@ else
 	pushd "$WORKSPACE/layers/meta-balena" > /dev/null 2>&1
 	git config --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pr/*'
 	git fetch --all
-	git checkout --force --recurse-submodule "$metaBalenaBranch"
+	git checkout --force "$metaBalenaBranch"
+	git submodule update --init --recursive
 	popd > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
If the submodule was recently added to meta-balena, the checkout
command will not initialize it without a separate submodule update
command.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>