### PR TITLE
jenkins_generate_ami: surface preload app commit as variable

### DIFF
--- a/automation/entry_scripts/balena-generate-ami.sh
+++ b/automation/entry_scripts/balena-generate-ami.sh
@@ -23,6 +23,7 @@ ensure_all_env_variables_are_set() {
                          AMI_NAME
                          AMI_ARCHITECTURE
                          BALENA_PRELOAD_APP
+			 BALENA_PRELOAD_COMMIT
                          BALENARC_BALENA_URL
                          BALENACLI_TOKEN
                          PRELOAD_SSH_PUBKEY"
@@ -118,7 +119,7 @@ deploy_preload_app_to_image() {
     balena preload \
       --debug \
       --app "${BALENA_PRELOAD_APP}" \
-      --commit current \
+      --commit "${BALENA_PRELOAD_COMMIT}" \
       "${image}"
 }
 

--- a/automation/jenkins_generate_ami.sh
+++ b/automation/jenkins_generate_ami.sh
@@ -64,6 +64,7 @@ fi
 
 APP_SUFFIX="${JSON_ARCH}"
 BALENA_PRELOAD_APP="cloud-config-${APP_SUFFIX}"
+BALENA_PRELOAD_COMMIT="${BALENA_PRELOAD_COMMIT:-current}"
 
 # shellcheck disable=SC1004
 # AWS_SESSION_TOKEN only needed if MFA is enabled for the account


### PR DESCRIPTION
Surface the preloaded app commit as a variable that can be overridden in
the build job. Default to "current" to maintain existing behavior when
the variable isn't set.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>