### PR TITLE
automation: ami: make BALENA_PRELOAD_COMMIT optional

### DIFF
--- a/automation/entry_scripts/balena-generate-ami.sh
+++ b/automation/entry_scripts/balena-generate-ami.sh
@@ -23,7 +23,6 @@ ensure_all_env_variables_are_set() {
                          AMI_NAME
                          AMI_ARCHITECTURE
                          BALENA_PRELOAD_APP
-			 BALENA_PRELOAD_COMMIT
                          BALENARC_BALENA_URL
                          BALENACLI_TOKEN
                          PRELOAD_SSH_PUBKEY"


### PR DESCRIPTION
Remove BALENA_PRELOAD_COMMIT from required env vars, as we have a
default if it's not specified.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>