### PR TITLE
deploy: ensure deployRawArtifact is empty instead of null

### DIFF
--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -42,7 +42,7 @@ balena_deploy_artifacts () {
 	_deploy_artifact=$(jq --raw-output '.yocto.deployArtifact' "${_device_type_json}")
 	_image=$(jq --raw-output '.yocto.image' "${_device_type_json}")
 	_deploy_flasher_artifact=$(jq --raw-output '.yocto.deployFlasherArtifact // empty' "${_device_type_json}")
-	_deploy_raw_artifact=$(jq --raw-output '.yocto.deployRawArtifact' "${_device_type_json}")
+	_deploy_raw_artifact=$(jq --raw-output '.yocto.deployRawArtifact // empty' "${_device_type_json}")
 	_compressed=$(jq --raw-output '.yocto.compressed' "${_device_type_json}")
 	_archive=$(jq --raw-output '.yocto.archive' "$_device_type_json")
 	_device_state=$(jq --raw-output '.state' "${_device_type_json}")


### PR DESCRIPTION
jq returns null by default when a given key isn't found, ensure that
when getting the value of deployRawArtifact, we get an empty variable
instead, which is checked later on to determine if that file should be
deployed

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>