### PR TITLE
balena-lib: fix 'fatal: unsafe repository'

### DIFF
--- a/automation/include/balena-lib.inc
+++ b/automation/include/balena-lib.inc
@@ -12,6 +12,10 @@ NAMESPACE="${NAMESPACE:-"resin"}"
 
 # Return the latest tag of the device repository
 balena_lib_get_os_version() {
+	# Fixes "fatal: unsafe repository"
+	# https://lore.kernel.org/git/xmqqv8veb5i6.fsf@gitster.g/
+	git config --add safe.directory "${device_dir}"
+
 	pushd "${device_dir}" > /dev/null 2>&1 || return
 	_version=$(git describe --abbrev=0)
 	popd > /dev/null 2>&1 || return


### PR DESCRIPTION
Git 2.35.2 was released to fix a security issue with multi-user
machines. Add `device_dir` to the whitelist to avoid this error.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>