### PR TITLE
balena-lib: fix 445d6d1fcfce97f85ffcfedc0083eb658a734321

### DIFF
--- a/automation/include/balena-lib.inc
+++ b/automation/include/balena-lib.inc
@@ -14,7 +14,7 @@ NAMESPACE="${NAMESPACE:-"resin"}"
 balena_lib_get_os_version() {
 	# Fixes "fatal: unsafe repository"
 	# https://lore.kernel.org/git/xmqqv8veb5i6.fsf@gitster.g/
-	git config --add safe.directory "${device_dir}"
+	git config --global --add safe.directory "${device_dir}"
 
 	pushd "${device_dir}" > /dev/null 2>&1 || return
 	_version=$(git describe --abbrev=0)


### PR DESCRIPTION
Commit 445d6d1fcfce97f85ffcfedc0083eb658a734321 does not fix
the issue because it is missing the --global arg without which
the git config command fails.

Change-type: patch
Signed-off-by: Florin Sarbu <florin@balena.io>