### PR TITLE
jenkins_build: Only deploy AMI after deploying a final release

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -176,7 +176,7 @@ if [ "$deploy" = "yes" ]; then
 		fi
 	fi
 
-	if [ "$AMI" = "true" ]; then
+	if [ "$AMI" = "true" ] && [ "${final}" = "yes" ]; then
 		echo "[INFO] Generating AMI"
 		export automation_dir
 		export MACHINE


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>