### PR TITLE
jenkins_build: secure boot & FDE AMI images support

### DIFF
--- a/automation/entry_scripts/balena-generate-ami.sh
+++ b/automation/entry_scripts/balena-generate-ami.sh
@@ -141,6 +141,7 @@ create_aws_ami() {
     --name "${AMI_NAME}" \
     --architecture "${AMI_ARCHITECTURE}" \
     --virtualization-type hvm \
+    --tpm-support v2.0 \
     --ena-support \
     --root-device-name "${AMI_ROOT_DEVICE_NAME}" \
     --boot-mode "${AMI_BOOT_MODE}" \

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -12,8 +12,8 @@ print_help() {
 	\t\t\t (mandatory) Machine to build for. This is a mandatory argument\n
 	\t\t --shared-dir\n\
 	\t\t\t (mandatory) Directory where to store shared downloads and shared sstate.\n
-	\t\t -b | --build-flavor\n\
-	\t\t\t (mandatory) The build flavor. (prod | dev)\n
+	\t\t -d | --os-dev\n\
+	\t\t\t Build an OS development image\n
 	\t\t -a | --additional-variable\n\
 	\t\t\t (optional) Inject additional local.conf variables. The format of the arguments needs to be VARIABLE=VALUE.\n\
 	\t\t --meta-balena-branch\n\
@@ -44,6 +44,7 @@ ESR=${ESR:-false}
 AMI=${AMI:-false}
 BARYS_ARGUMENTS_VAR="--remove-build"
 REMOVE_CONTAINER="--rm"
+OS_DEVELOPMENT=${OS_DEVELOPMENT:-false}
 
 # process script arguments
 args_number="$#"
@@ -98,6 +99,9 @@ while [[ $# -ge 1 ]]; do
 		--esr)
 			ESR="true"
 			;;
+		-d|--os-dev)
+			OS_DEVELOPMENT="true"
+			;;
 		--preserve-build)
 			PRESERVE_BUILD=1
 			BARYS_ARGUMENTS_VAR=${BARYS_ARGUMENTS_VAR//--remove-build/}
@@ -141,6 +145,10 @@ else
 	git checkout --force "$metaBalenaBranch"
 	git submodule update --init --recursive
 	popd > /dev/null 2>&1
+fi
+
+if [ "${OS_DEVELOPMENT}" = "true" ]; then
+	BARYS_ARGUMENTS_VAR="${BARYS_ARGUMENTS_VAR} -d"
 fi
 
 "${automation_dir}"/../build/balena-build.sh -d "${MACHINE}" -s "${JENKINS_PERSISTENT_WORKDIR}" -a "$(balena_lib_environment)" -g "${BARYS_ARGUMENTS_VAR}"

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -28,6 +28,9 @@ print_help() {
 	\t\t --preserve-container\n\
 	\t\t\t (optional) Do not delete the yocto build docker container when it exits.\n\
 \t\t\t\t Default is to delete the container where the yocto build is taking place when this container exits.\n
+	\t\t --ami-image-type\n\
+	\t\t\t (optional) Specify image type to use for AMI image creation.\n\
+\t\t\t\t Defaults to using direct boot image, set to *installer* to use the installer image instead .\n\
 	\t\t --esr\n\
 	\t\t\t (optional) Is this an ESR build\n\
 \t\t\t\t Defaults to false.\n"
@@ -95,6 +98,13 @@ while [[ $# -ge 1 ]]; do
 				exit 1
 			fi
 			supervisorVersion="${supervisorVersion:-$2}"
+			;;
+		--ami-image-type)
+			if [ -z "$2" ]; then
+				echo "--ami-image-type argument needs an image type to use , by default it uses the direct boot image)"
+				exit 1
+			fi
+			AMI_IMAGE_TYPE="${AMI_IMAGE_TYPE:-${2}}"
 			;;
 		--esr)
 			ESR="true"
@@ -188,6 +198,7 @@ if [ "$deploy" = "yes" ]; then
 		echo "[INFO] Generating AMI"
 		export automation_dir
 		export MACHINE
+		export AMI_IMAGE_TYPE
 		"${automation_dir}"/jenkins_generate_ami.sh
 	fi
 

--- a/automation/jenkins_generate_ami.sh
+++ b/automation/jenkins_generate_ami.sh
@@ -38,7 +38,11 @@ fi
 YOCTO_IMAGES_PATH="${WORKSPACE}/build/tmp/deploy/images/${MACHINE}"
 
 # TODO: Replace the default value with the value read from the CoffeeScript file once available
-IMAGE_NAME=${IMAGE_NAME:-balena-image-${MACHINE}.balenaos-img}
+if [ -n "${AMI_IMAGE_TYPE}" ] && [ "${AMI_IMAGE_TYPE}" = "installer" ]; then
+    IMAGE_NAME=${IMAGE_NAME:-balena-image-flasher-${MACHINE}.balenaos-img}
+else
+    IMAGE_NAME=${IMAGE_NAME:-balena-image-${MACHINE}.balenaos-img}
+fi
 
 ORIG_IMAGE="${YOCTO_IMAGES_PATH}/${IMAGE_NAME}"
 PRELOADED_IMAGE="$(mktemp -p "${YOCTO_IMAGES_PATH}")"
@@ -51,7 +55,11 @@ VERSION=$(cat < "${YOCTO_IMAGES_PATH}/VERSION_HOSTOS" | sed 's/+/-/g')
 # AMI name format: balenaOS-VERSION-DEVICE_TYPE
 # shellcheck disable=SC2154
 # passed in by Jenkins
-AMI_NAME="balenaOS-${VERSION}-${MACHINE}"
+if [ -n "${AMI_IMAGE_TYPE}" ] && [ "${AMI_IMAGE_TYPE}" = "installer" ]; then
+    AMI_NAME="${AMI_NAME:-balenaOS-${AMI_IMAGE_TYPE}-${VERSION}-${MACHINE}}"
+else
+    AMI_NAME="${AMI_NAME:-balenaOS-${VERSION}-${MACHINE}}"
+fi
 
 # TODO: Can get the mapping from somewhere?
 JSON_ARCH=$(balena_lib_get_dt_arch "${MACHINE}")


### PR DESCRIPTION
Building OS development images is useful for example when debugging and testing AMI images.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>