### PR TITLE
balena-generate-ami: Enable TPM support on x86_64 only

### DIFF
--- a/automation/entry_scripts/balena-generate-ami.sh
+++ b/automation/entry_scripts/balena-generate-ami.sh
@@ -136,12 +136,17 @@ create_aws_ami() {
         exit 1
     fi
 
+    # Only supported on x86_64
+    if [ "${AMI_ARCHITECTURE}" = "x86_64" ]; then
+        TPM="--tpm-support v2.0"
+    fi
+
     echo "Creating ${AMI_NAME} AWS AMI image..."
     image_id=$(aws ec2 register-image \
     --name "${AMI_NAME}" \
     --architecture "${AMI_ARCHITECTURE}" \
     --virtualization-type hvm \
-    --tpm-support v2.0 \
+    ${TPM} \
     --ena-support \
     --root-device-name "${AMI_ROOT_DEVICE_NAME}" \
     --boot-mode "${AMI_BOOT_MODE}" \


### PR DESCRIPTION
On aarch64 this fails with `Invalid machineArchitecture value 'arm64' for tpmSupport`