### PR TITLE
balena-api: ignore quotes from API replies

### DIFF
--- a/automation/include/balena-api.inc
+++ b/automation/include/balena-api.inc
@@ -36,10 +36,10 @@ __dlog() {
 __check_fail() {
 	local _json
 	local _msg
-	_json="$1"
-	_msg="$2"
+	_json="${1%\"}"
+	_msg="${2}"
 
-	if [ "${_json}" != "OK" ]; then
+	if [ "${_json#\"}" != "OK" ]; then
 		__pp_json "${_json}"
 		__dlog "${_msg}"
 		return 0


### PR DESCRIPTION
The balenaAPI has replied both `OK` and `"OK"` to patch requests. Accept any of them as long as they contain OK.

Change-type: patch