### PR TITLE
barys: fix removal of equals sign from argval

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -475,8 +475,8 @@ if [ "x$BUILD_HISTORY" == "xyes" ]; then
     echo 'BUILDHISTORY_COMMIT = "1"' >>conf/local.conf
 fi
 for pair in $ADDITIONAL_VARIABLES; do
-    variable=$(echo "$pair" | awk -F= '{print $1}')
-    value=$(echo "$pair" | awk -F= '{print $2}')
+    variable=$(echo "$pair" | cut -d= -f1)
+    value=$(echo "$pair" | cut -d= -f2-)
     echo "$variable=\"$value\"" >> conf/local.conf
 done
 


### PR DESCRIPTION
When parsing additional variables to be passed to the bitbake build, keys and values are split using equals as a delimiter. However, the splitting process does not split only on the first occurrence, which results in removing equals signs from the value as well. This is problematic with base64 encoded strings, which are padded with equals signs.

Split only on the first occurrence, leaving the value intact.

Change-type: patch