### PR TITLE
balena-deploy: add secureBoot feature into contract

### DIFF
--- a/automation/entry_scripts/balena-deploy-block.sh
+++ b/automation/entry_scripts/balena-deploy-block.sh
@@ -27,6 +27,9 @@ fi
 
 if [ -f "/deploy/balena.yml" ]; then
 	echo -e "\nversion: $(balena_lib_get_os_version)" >> "/deploy/balena.yml"
+	if [ "${SECURE_BOOT_FEATURE_FLAG}" = "yes" ]; then
+		sed -i '/provides:/a \  - type: sw.feature\n    slug: secureboot' "/deploy/balena.yml"
+	fi
 fi
 
 echo "[INFO] Deploying  to ${BALENAOS_ACCOUNT}/$APPNAME"

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -271,11 +271,12 @@ balena_deploy_block() {
 	local _image_path="${4:-""}"
 	local _deploy="${5:-no}"
 	local _final="${6:-no}"
-	local _work_dir="${7:-"${device_dir}"}"
-	local _balenaos_account="${8:-"balena_os"}"
-	local _balenaCloudEmail="${9:-"${balenaCloudEmail}"}"
-	local _balenaCloudPassword="${10:-"${balenaCloudPassword}"}"
-	local _esr="${11}"
+	local _sb_feature_flag="${7:-no}"
+	local _work_dir="${8:-"${device_dir}"}"
+	local _balenaos_account="${9:-"balena_os"}"
+	local _balenaCloudEmail="${10:-"${balenaCloudEmail}"}"
+	local _balenaCloudPassword="${11:-"${balenaCloudPassword}"}"
+	local _esr="${12}"
 	local _discontinued
 	local _api_env=$(balena_lib_environment)
 
@@ -318,6 +319,7 @@ balena_deploy_block() {
 		-e DEPLOY="${_deploy}" \
 		-e FINAL="${_final}" \
 		-e ESR="${_esr:-"false"}" \
+		-e SECURE_BOOT_FEATURE_FLAG="${_sb_feature_flag:-"no"}" \
 		-e balenaCloudEmail="${_balenaCloudEmail}" \
 		-e balenaCloudPassword="${_balenaCloudPassword}" \
 		-e ESR="${_esr}" \

--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -192,10 +192,15 @@ balena_deploy_artifacts "${MACHINE}" "$WORKSPACE/deploy-jenkins" "true"
 if [ "$deploy" = "yes" ]; then
 	echo "[INFO] Starting deployment..."
 
+	secureBoot="no"
+	if [ -n "${SIGN_API_URL}" ]; then
+		secureBoot="yes"
+	fi
+
 	balena_deploy_to_s3 "$MACHINE" "${ESR}" "${deployTo}"
 	_image_path=$(find "${WORKSPACE}/build/tmp/deploy/" -name "balena-image-${MACHINE}.docker" -type l || true)
 	if [ -n "${_image_path}" ] && [ -f "${_image_path}" ]; then
-		balena_deploy_block "$(balena_lib_get_slug "${MACHINE}")" "${MACHINE}" "${_bootable:-1}" "${_image_path}" "${deploy}" "${final}"
+		balena_deploy_block "$(balena_lib_get_slug "${MACHINE}")" "${MACHINE}" "${_bootable:-1}" "${_image_path}" "${deploy}" "${final}" "${secureBoot}"
 	else
 		_state=$(balena_lib_get_dt_state "${MACHINE}")
 		if [ "${_state}" != "DISCONTINUED" ]; then


### PR DESCRIPTION
When building signed images, add the secureBoot feature flag into the OS contract. This is needed for other components to identify secureBoot compatible software releases.

Change-type: patch