### PR TITLE
balena-deploy: Newer meta-balena do not create a kernel_source tarball

### DIFF
--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -76,8 +76,12 @@ balena_deploy_artifacts () {
 		return
 	fi
 
-	cp -v "$_yocto_build_deploy/kernel_modules_headers.tar.gz" "$_deploy_dir" || true
-	cp -v "$_yocto_build_deploy/kernel_source.tar.gz" "$_deploy_dir" || true
+	if [ -f "$_yocto_build_deploy/kernel_modules_headers.tar.gz" ]; then
+		cp -v "$_yocto_build_deploy/kernel_modules_headers.tar.gz" "$_deploy_dir" || true
+	fi
+	if [ -f "$_yocto_build_deploy/kernel_source.tar.gz" ]; then
+		cp -v "$_yocto_build_deploy/kernel_source.tar.gz" "$_deploy_dir" || true
+	fi
 	if [ "${_compressed}" != 'true' ]; then
 		# uncompressed, just copy and we're done
 		cp -v "$(readlink --canonicalize "$_yocto_build_deploy/$_deploy_artifact")" "$_deploy_dir/image/balena.img"


### PR DESCRIPTION
This artifact did not contain kernel sources since Yocto Thud.

Changelog-entry: The kernel_source tarball is no longer created by meta-balena