### PR TITLE
Fail deploy if script fails to find DT

### DIFF
--- a/automation/include/balena-api.inc
+++ b/automation/include/balena-api.inc
@@ -432,10 +432,6 @@ balena_api_is_dt_private() {
 	_token=$(balena_lib_token)
 
 	_is_private=$(${CURL} -XGET -H "Content-type: application/json" -H "Authorization: bearer ${_token}" --silent --retry 5 "https://api.${_api_env}/${TRANSLATION}/device_type?\$filter=slug%20eq%20%27${_slug}%27&\$select=slug,is_private" | jq -r '.d[0].is_private')
-	if [ -z "${_is_private}" ] || [ "${_is_private}" = "null" ]; then
-		>&2 echo "[] Device type not found, assuming private"
-		echo "true"
-	fi
 	echo "${_is_private}"
 }
 

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -199,6 +199,10 @@ balena_deploy_to_s3() {
 	_is_private=$(balena_api_is_dt_private "${_device_type}")
 	if [ "${_is_private}" = "false" ]; then
 		_s3_policy="public-read"
+	elif [ -z "${_is_private}" ] || [ "${_is_private}" = "null" ]; then
+		# If _is_private is empty, or a null value, the curl to retrieve it has failed
+		echo "[ERROR] Device type not found..."
+		return 1
 	fi
 
 	local _s3_cmd="s4cmd --access-key=${_s3_access_key} --secret-key=${_s3_secret_key}"


### PR DESCRIPTION
There is a bug when the curl GET to check if a DT is private or not fails - it assumes the device type is private. This can lead to s3 artifacts for public DT's not being marked as public-read, if the curl fails (for example if there are api errors or connectivity issues)

