### PR TITLE
Dockerfile_yocto-build-env: Add screen

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales zstd liblz4-tool \
                                          texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
                                          python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
-                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils \
+                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils screen \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty


### PR DESCRIPTION
To enable us to use `bitbake -c devshell foo` in container