### PR TITLE
Merge AMI publishing dependencies into yocto-build-env

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -29,4 +29,4 @@ jobs:
     with:
       docker_images: |
         ghcr.io/balena-os/balena-yocto-scripts
-      bake_targets: yocto-build-env,balena-push-env,yocto-generate-ami-env
+      bake_targets: yocto-build-env,balena-push-env

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -45,14 +45,11 @@ RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA
 COPY include/balena-docker.inc /
 COPY entry_scripts/prepare-and-start.sh /
 
-WORKDIR /work
-
-####################
-
-FROM yocto-build-env AS yocto-generate-ami-env
-
-RUN apt-get update && apt-get install -y python3-pip udev && rm -rf /var/lib/apt/lists/*
-RUN pip3 install awscli
-
+# scripts and packages required for AMI publishing
 COPY include/balena-api.inc include/balena-lib.inc entry_scripts/balena-generate-ami.sh /
-WORKDIR /
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && apt-get install -y python3-pip udev && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir awscli
+
+WORKDIR /work

--- a/automation/jenkins_generate_ami.sh
+++ b/automation/jenkins_generate_ami.sh
@@ -30,7 +30,7 @@ HELPER_IMAGE_REPO="${HELPER_IMAGE_REPO:-"ghcr.io/balena-os/balena-yocto-scripts"
 # shellcheck disable=SC1091,SC2154
 source "${automation_dir}/include/balena-lib.inc"
 
-if ! balena_lib_docker_pull_helper_image "${HELPER_IMAGE_REPO}" "" "yocto-generate-ami-env" helper_image_id; then
+if ! balena_lib_docker_pull_helper_image "${HELPER_IMAGE_REPO}" "" "yocto-build-env" helper_image_id; then
     exit 1
 fi
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,16 +8,6 @@ target "yocto-build-env" {
   ]
 }
 
-target "yocto-generate-ami-env" {
-  context = "automation"
-  dockerfile = "Dockerfile_yocto-build-env"
-  target = "yocto-generate-ami-env"
-  platforms = [
-    "linux/amd64",
-    // "linux/arm64"
-  ]
-}
-
 target "balena-push-env" {
   context = "automation"
   dockerfile = "Dockerfile_balena-push-env"


### PR DESCRIPTION
This allows us to build and publish fewer helper images.

Change-type: patch