### PR TITLE
balena-build: avoid using device-type as a prefix in yocto sstate

### DIFF
--- a/build/balena-build.sh
+++ b/build/balena-build.sh
@@ -66,7 +66,7 @@ balena_build_run_barys() {
 	[ -z "${_bitbake_args}" ] && _bitbake_args=""
 	[ -z "${_bitbake_targets}" ] && _bitbake_targets=""
 	_dl_dir="${_shared_dir}/shared-downloads"
-	_sstate_dir="${_shared_dir}/${_device_type}/sstate"
+	_sstate_dir="${_shared_dir}/sstate"
 	mkdir -p "${_dl_dir}"
 	mkdir -p "${_sstate_dir}"
 	[ -n "${_bitbake_args}" ] && _bitbake_args="--bitbake-args ${_bitbake_args}"


### PR DESCRIPTION
Yocto already splits the build sstate by target arch, native arch, toolchains, and machine where applicable.

Keeping the caches separated by device type prevents sharing of common cache steps between identical toolchains and architectures.

Change-type: patch