### PR TITLE
Revert "balena-build: avoid using device-type as a prefix in yocto sstate"

### DIFF
--- a/build/balena-build.sh
+++ b/build/balena-build.sh
@@ -66,7 +66,7 @@ balena_build_run_barys() {
 	[ -z "${_bitbake_args}" ] && _bitbake_args=""
 	[ -z "${_bitbake_targets}" ] && _bitbake_targets=""
 	_dl_dir="${_shared_dir}/shared-downloads"
-	_sstate_dir="${_shared_dir}/sstate"
+	_sstate_dir="${_shared_dir}/${_device_type}/sstate"
 	mkdir -p "${_dl_dir}"
 	mkdir -p "${_sstate_dir}"
 	[ -n "${_bitbake_args}" ] && _bitbake_args="--bitbake-args ${_bitbake_args}"


### PR DESCRIPTION
This reverts commit f4a9566941083770151ebe3edd78e9866b4856fb.

The original change introduced unexpected breaking issues in the build cache as captured in [this](https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/.E2.9C.94.20Build.20Failures.20-.20bigmak-imx8m-plus) thread.