### PR TITLE
balena-deploy: deploy usbboot if available

### DIFF
--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -66,6 +66,10 @@ balena_deploy_artifacts () {
 		cp -v "${device_dir}/CHANGELOG.md" "${_deploy_dir}"
 	fi
 
+	if [ -d "$_yocto_build_deploy/usbboot" ]; then
+		cp -rv "$_yocto_build_deploy/usbboot" "$_deploy_dir" || true
+	fi
+
 	test "${_slug}" = "edge" && return
 
 	if [ "$_deploy_artifact" = "docker-image" ]; then


### PR DESCRIPTION
This is where the RPI family deploys provisioning artifacts.

Change-type: patch