### PR TITLE
balena-lib: improve base tag detection

### DIFF
--- a/automation/include/balena-lib.inc
+++ b/automation/include/balena-lib.inc
@@ -41,7 +41,7 @@ balena_lib_get_meta_balena_base_version() {
 	git config --global --add safe.directory "${device_dir}/layers/meta-balena"
 
 	pushd "${device_dir}/layers/meta-balena" > /dev/null 2>&1 || return
-	_version=$(git describe "$(git rev-list --first-parent -1 HEAD)"^1)
+	_version=$(git tag --points-at $(git merge-base HEAD master))
 	popd > /dev/null 2>&1 || return
 	echo "${_version%+*}"
 }


### PR DESCRIPTION
When a ESR release is deployed a tag with the base meta-balena version is created. This is used by the API to check for a valid OS version for updates.

The current mechanism to find the base version only provides an ESR version for the first commit after the branch has been created.

Using merge-base to find the common ancestor and `tag --points-at` to find the actual tag works for all commits after the branch is created.

Change-type: patch