### PR TITLE
Support commit tags when extracting version tag from git

### DIFF
--- a/automation/include/balena-lib.inc
+++ b/automation/include/balena-lib.inc
@@ -17,7 +17,7 @@ balena_lib_get_os_version() {
 	git config --global --add safe.directory "${device_dir}"
 
 	pushd "${device_dir}" > /dev/null 2>&1 || return
-	_version=$(git describe --abbrev=0)
+	_version=$(git describe --tags --abbrev=0)
 	popd > /dev/null 2>&1 || return
 	echo "${_version#v*}"
 }


### PR DESCRIPTION
Git describe does not include commit tags by default, and only annotated tags are shown.

This behaviour was fine until a recent CI issue changed the types of tags used to version the repositories.

This commit allows supporting of both types while the CI issue is investigated.

Change-type: patch