### PR TITLE
Add catchall job to yocto-build-deploy for merge requirements

### DIFF
--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -77,6 +77,15 @@ jobs:
   yocto:
     name: Yocto
     uses: ./.github/workflows/yocto-build-deploy.yml
+    # prevent duplicate workflow executions for pull_request and pull_request_target
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event_name == 'pull_request'
+      ) || (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event_name == 'pull_request_target'
+      )
     secrets: inherit
     with:
       # runs-on: '[ "ubuntu-latest" ]'

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1192,3 +1192,40 @@ jobs:
           # Two variables extra for this job
           QEMU_SECUREBOOT: 1
           FLASHER_SECUREBOOT: 1
+
+  # This job always runs and will fail if any of the builds or tests fail.
+  # This way we can mark this job as required for merging PRs.
+  # Otherwise we would need to mark each build and test matrix, suite, etc. as required.
+  all_jobs:
+    name: All jobs
+    needs:
+      - build
+      - test
+    runs-on: ubuntu-latest
+    # Do not skip this job if needed jobs are skipped, as we always
+    # want to capture pass/fail for the entire workflow and skipped
+    # jobs count as passing as far as required checks go.
+    if: |
+      always() && inputs.run-tests == true
+
+    defaults:
+      run:
+        working-directory: .
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    steps:
+      - name: Reject failed jobs
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ]
+          then
+            echo "One or more tests have failed"
+            exit 1
+          fi
+
+      - name: Reject cancelled jobs
+        run: |
+          if [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]
+          then
+            echo "One or more tests were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1202,11 +1202,13 @@ jobs:
       - build
       - test
     runs-on: ubuntu-latest
-    # Do not skip this job if needed jobs are skipped, as we always
-    # want to capture pass/fail for the entire workflow and skipped
-    # jobs count as passing as far as required checks go.
+    # The default condition for jobs is success(), which means that this
+    # job would be skipped if a previous job failed.
+    # Unfortunately GitHub treats skipped jobs as a pass as far as merge requirements!
+    # So we override the conditions of this job to always run, and check
+    # the results of the previous jobs to return overall success or failure.
     if: |
-      always() && inputs.run-tests == true
+      always()
 
     defaults:
       run:
@@ -1218,7 +1220,7 @@ jobs:
         run: |
           if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ]
           then
-            echo "One or more tests have failed"
+            echo "One or more jobs have failed"
             exit 1
           fi
 
@@ -1226,6 +1228,6 @@ jobs:
         run: |
           if [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]
           then
-            echo "One or more tests were cancelled"
+            echo "One or more jobs were cancelled"
             exit 1
           fi


### PR DESCRIPTION
This is a helper job to avoid having to mark all build/test matrices as required, as this job will always run and return success or failure.

Change-type: patch