### PR TITLE
Simplify matrix generation

### DIFF
--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -95,7 +95,10 @@ jobs:
       #   for device types we use virtualised testing for: test-workers
       machine: generic-amd64
       test-environment: bm.balena-dev.com
-      test-workers: qemu
+      test-workers: >
+        [
+          "qemu"
+        ]
       # Allow overriding these inputs for manual triggers
       environment: ${{ inputs.environment || 'balena-staging.com' }}
       sign-image: ${{ inputs.sign-image || false }}

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -132,15 +132,24 @@ on:
         type: string
         default: "us-east-1"
       test-suites:
-        description: "Comma-separated list of test suites to run. No spaces in between."
+        description: "JSON list with the test suites to run."
         required: false
         type: string
-        default: "os,hup,cloud"
+        default: >
+          [
+            "os",
+            "hup",
+            "cloud"
+          ]
       test-workers:
-        description: "Comma-separated list of worker types to use for testing. No spaces in between. The valid worker types are `qemu` and `testbot`."
+        description: "JSON list of worker types to use for testing. Valid element values are `qemu` and `testbot`."
         required: false
         type: string
-        default: "testbot" # Most devices use "testbot" , so qemu is the exception and should be set at the device repo level
+        # Most devices use "testbot", so "qemu" is the exception and should be set at the device repo level
+        default: >
+          [
+            "testbot"
+          ]
       worker-fleets:
         description: "Testbot fleet for finding available Leviathan workers. Not used for QEMU workers. Can accept a list of apps separated by commas, no spaces in between."
         type: string
@@ -962,65 +971,6 @@ jobs:
       #       -w "${WORKSPACE}" \
       #       "${{ steps.ami-helper-image.outputs.id }}" /balena-generate-ami.sh
 
-
-      # Creates an array for the test workers types - e.g qemu or testbot
-      # Example output: JSON_ARRAY='["qemu"]'
-      # Required to create test suite matrix
-      # TODO: if GH actions ever start support splitting string then remove this
-      - id: test_workers
-        name: Prerequiste - Create a JSON array for test_workers
-        shell: bash
-        run: |
-          set -x
-
-          # Remove spaces and newlines from the input
-          INPUT="$(echo "${INPUT}" | tr -d '[:space:]')"
-
-          # Convert to JSON array using jq to split the string by the given delimiter
-          # Add a step to check if the array is empty, default to [""] if so
-          JSON_ARRAY="$(jq --raw-input --compact-output --null-input --arg delim "$DELIMITER" --arg input "$INPUT" '
-            if $input == "" then
-              [""] # Default to a single empty string element if input is empty
-            else
-              $input | split($delim) # Split the input by the delimiter
-            end
-          ')"
-
-          echo "build=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-          echo "json=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-        env:
-          INPUT: ${{ inputs.test-workers }}
-          DELIMITER: ","
-
-      # Creates an array for the test suites
-      # Example output: JSON_ARRAY='["os","hup","cloud"]'
-      # Required to create test suite matrix
-      # TODO: if GH actions ever start support splitting string then remove this
-      - id: test_suites
-        name: Prerequiste - Create a JSON array for test_suites
-        shell: bash
-        run: |
-          set -x
-
-          # Remove spaces and newlines from the input
-          INPUT="$(echo "${INPUT}" | tr -d '[:space:]')"
-
-          # Convert to JSON array using jq to split the string by the given delimiter
-          # Add a step to check if the array is empty, default to [""] if so
-          JSON_ARRAY="$(jq --raw-input --compact-output --null-input --arg delim "$DELIMITER" --arg input "$INPUT" '
-            if $input == "" then
-              [""] # Default to a single empty string element if input is empty
-            else
-              $input | split($delim) # Split the input by the delimiter
-            end
-          ')"
-
-          echo "build=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-          echo "json=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-        env:
-          INPUT: ${{ inputs.test-suites }}
-          DELIMITER: ","
-
       # Creates a test matrix to test the specified suites, on specified workers
       # We do this to run each suite in parallel if there are available workers, and to be able to retry individual test suites
       # Example output: + json='{"TEST_SUITE":["os","hup","cloud"],"DEVICE_TYPE":["generic-amd64"],"ENVIRONMENT":["balenaos-balenamachine"],"WORKER_TYPE":["qemu"]}'
@@ -1030,10 +980,10 @@ jobs:
         env:
           MATRIX: >
             {
-              "TEST_SUITE": ${{ steps.test_suites.outputs.json }},
+              "TEST_SUITE": ${{ inputs.test-suites }},
               "DEVICE_TYPE": ${{ format('["{0}"]', steps.balena-lib.outputs.device_slug) }},
               "ENVIRONMENT": ${{ format('["{0}"]', inputs.test-environment) }},
-              "WORKER_TYPE": ${{ steps.test_workers.outputs.json }}
+              "WORKER_TYPE": ${{ inputs.test-workers }}
             }
         run: |
           echo $json

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -253,6 +253,28 @@ jobs:
             Please contact a member of the organization for assistance."
           exit 1
 
+      - name: Validate inputs
+        run: |
+          # We expect `jq` to fail when the input is invalid and that's fine
+          set +e
+
+          # The output we echo here shall be easier to follow than the -x trace
+          set +x
+
+          # Check if the string $2 (which is assumed to come from input $1) is a valid JSON array
+          validate_json_array() {
+            echo "$2" | jq ".[]"
+            status=$?
+            if [ $status -ne 0 ]; then
+              echo "INPUT ERROR: inputs.$1 must be a JSON array, got $2"
+              exit 1
+            fi
+          }
+
+          validate_json_array 'runs-on' '${{ inputs.runs-on }}'
+          validate_json_array 'test-suites' '${{ inputs.test-suites }}'
+          validate_json_array 'test-workers' '${{ inputs.test-workers }}'
+
       # this must be done before putting files in the workspace
       # https://github.com/easimon/maximize-build-space
       - name: Maximize build space


### PR DESCRIPTION
This is a more polished (and working!) version of my previous attempt to simplify the matrix generation.

Turns out my change by itself was OK, but I missed that `generic-amd64.yml` was setting `inputs.test-workers` to a value that was not in the format now expected. Not the commit updates this input, too.

And then I included a second commit that validates the inputs early on the workflow.
