### PR TITLE
Base image upgrade

### DIFF
--- a/automation/Dockerfile_balena-push-env
+++ b/automation/Dockerfile_balena-push-env
@@ -24,7 +24,7 @@ RUN curl -sSL https://download.docker.com/linux/static/edge/x86_64/docker-${DOCK
   && mv /docker/* /usr/local/bin/
 
 # Install balena-cli
-ENV BALENA_CLI_VERSION 17.2.2
+ENV BALENA_CLI_VERSION 18.2.2
 RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA_CLI_VERSION/balena-cli-v$BALENA_CLI_VERSION-linux-x64-standalone.zip > balena-cli.zip && \
   unzip balena-cli.zip && \
   mv balena-cli/* /usr/bin && \

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -1,12 +1,12 @@
-FROM ubuntu:18.04 AS yocto-build-env
+FROM ubuntu:22.04 AS yocto-build-env
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install the following utilities (required by poky)
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales zstd liblz4-tool \
-                                         texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
+                                         texinfo unzip wget xterm cpio file python3 openssh-client iputils-ping iproute2 \
                                          python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
-                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils screen rsync sharutils \
+                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint mesa-common-dev debianutils screen rsync sharutils \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty
@@ -15,24 +15,14 @@ ENV LANG en_US.UTF-8
 
 # Additional host packages required by balena
 RUN apt-get update && apt-get install -y apt-transport-https iptables iproute2 procps uidmap && rm -rf /var/lib/apt/lists/*
-RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-ENV NODE_VERSION node_8.x
-ENV DISTRO bionic
-RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list &&\
-  echo "deb-src https://deb.nodesource.com/$NODE_VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update && apt-get install -y jq nodejs sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y jq nodejs npm sudo && rm -rf /var/lib/apt/lists/*
 
 # Additional host packages required by various BSP layers
 RUN apt-get update && apt-get install -y dos2unix && rm -rf /var/lib/apt/lists/*
 
 # Install docker matching the balena-engine version
 # https://docs.docker.com/engine/install/ubuntu/
-RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-ENV DOCKER_VERSION="5:19.03.13~3-0~ubuntu-bionic"
-RUN apt-get update && apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} containerd.io && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release docker.io && rm -rf /var/lib/apt/lists/*
 VOLUME /var/lib/docker
 
 # Install balena-cli

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-u
 VOLUME /var/lib/docker
 
 # Install balena-cli
-ENV BALENA_CLI_VERSION 17.2.2
+ENV BALENA_CLI_VERSION 18.2.2
 RUN curl -sSL https://github.com/balena-io/balena-cli/releases/download/v$BALENA_CLI_VERSION/balena-cli-v$BALENA_CLI_VERSION-linux-x64-standalone.zip > balena-cli.zip && \
   unzip balena-cli.zip && \
   mv balena-cli/* /usr/bin && \


### PR DESCRIPTION
Upgrade the image base from Ubuntu:18.04 to Ubuntu:22.04, bringing a new docker engine version, and compatibility with cgroup v2 on the host.