### PR TITLE
GHA workflow: Simplify check for secure boot

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -602,15 +602,6 @@ jobs:
       # hostapp Deploy
       ##############################
 
-      - name: Set SECURE_BOOT_FEATURE_FLAG
-        if: inputs.deploy-hostapp == true
-        run: |
-          if [ -n "${{ inputs.sign-image }}" = "true" ]; then
-            echo "SECURE_BOOT_FEATURE_FLAG=yes" >> $GITHUB_ENV
-          else
-            echo "SECURE_BOOT_FEATURE_FLAG=no" >> $GITHUB_ENV
-          fi
-
       - name: Check Balena CLI installation
         run: |
           balena --version
@@ -661,7 +652,7 @@ jobs:
 
           if [ -f "${WORKSPACE}/balena.yml" ]; then
             echo -e "\nversion: ${VERSION}" >> "${WORKSPACE}/balena.yml"
-            if [ "${SECURE_BOOT_FEATURE_FLAG}" = "yes" ]; then
+            if [ "${{ inputs.sign-image }}" = "true" ]; then
               sed -i '/provides:/a \  - type: sw.feature\n    slug: secureboot' "/${WORKSPACE}/balena.yml"
             fi
           fi


### PR DESCRIPTION
I spotted a typo/bug in the check for secure boot this while [checking this test run](https://github.com/balena-io-experimental/balena-raspberrypi-gha/actions/runs/9681366732/job/26756255483#step:29:27):

```
# Mixing a check for string length with an equality check!
if [ -n "${{ inputs.sign-image }}" = "true" ]; then
```

Then I noticed we could use `inputs.sign-image` directly, without going through a new variable `SECURE_BOOT_FEATURE_FLAG`. This also removes the small complexity of one thing being true/false and the other being yes/no.
