### PR TITLE
Stop uploading to GH artifacts storage when PR is closed

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -503,6 +503,7 @@ jobs:
       # Separate "flasher" and "raw" variants are not used in the testing flow
       - name: Upload artifacts
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        if: github.event_name != 'push'
         with:
           name: build-artifacts
           if-no-files-found: error


### PR DESCRIPTION
Uploading artifacts to GH artifact storage when PR is merged (closed event) is wasterful. Since they are only uploaded for temporary basis so it can be used for testing. Hence, the PR to stop doing that for `closed` PR event

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
