### PR TITLE
Fix os contract building for private device types

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -362,6 +362,10 @@ jobs:
       # A lot of outputs inferred from here are used everywhere else in the workflow
       - name: Set build outputs
         id: balena-lib
+        env: 
+          CURL: "curl --silent --retry 10 --location --compressed"
+          TRANSLATION: "v6"
+          BALENAOS_TOKEN: ${{ secrets.BALENA_API_DEPLOY_KEY }}
         run: |
           source "${automation_dir}/include/balena-api.inc"
           source "${automation_dir}/include/balena-lib.inc"
@@ -390,7 +394,9 @@ jobs:
           dt_arch="$(balena_lib_get_dt_arch "${MACHINE}")"
           echo "dt_arch=${dt_arch}" >> $GITHUB_OUTPUT
 
-          is_private="$(balena_api_is_dt_private "${{ inputs.machine }}")"
+          # Unrolled balena_api_is_dt_private function - https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-api.inc#L424
+          # Had to be unrolled due to this: https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-lib.inc#L191 function relying on a jenkins env var to select the balena env - so failed
+          is_private=$(${CURL} -XGET -H "Content-type: application/json" -H "Authorization: bearer ${BALENAOS_TOKEN}" --silent --retry 5 "https://api.${API_ENV}/${TRANSLATION}/device_type?\$filter=slug%20eq%20%27${device_slug}%27&\$select=slug,is_private" | jq -r '.d[0].is_private')
           echo "is_private=${is_private}" >> $GITHUB_OUTPUT
 
           if [ ! -f "${WORKSPACE}/balena.yml" ]; then

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -399,10 +399,33 @@ jobs:
           is_private=$(${CURL} -XGET -H "Content-type: application/json" -H "Authorization: bearer ${BALENAOS_TOKEN}" --silent --retry 5 "https://api.${API_ENV}/${TRANSLATION}/device_type?\$filter=slug%20eq%20%27${device_slug}%27&\$select=slug,is_private" | jq -r '.d[0].is_private')
           echo "is_private=${is_private}" >> $GITHUB_OUTPUT
 
-          if [ ! -f "${WORKSPACE}/balena.yml" ]; then
-            _contract=$(balena_lib_build_contract "${device_slug}")
-            cp "${_contract}" "${WORKSPACE}/balena.yml"
+      - name: Checkout private Contracts
+        uses: actions/checkout@v4.1.1
+        if: steps.balena-lib.outputs.is_private == 'true'
+        with:
+          repository: balena-io/private-contracts
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/private-contracts
+
+      # Unrolled balena_api_is_dt_private function - https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-api.inc#L424
+      # Had to be unrolled due to this: https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-lib.inc#L191 function relying on a jenkins env var to select the balena env - so failed
+      - name: Build OS contract
+        env:
+          CONTRACTS_BUILD_DIR: "${{ github.workspace }}/balena-yocto-scripts/build/contracts"
+          NODE: node
+          DEVICE_TYPE_SLUG: ${{ steps.balena-lib.outputs.device_slug }}
+          CONTRACTS_OUTPUT_DIR: "${{ github.workspace }}/build/contracts"
+        run: |
+          npm --prefix="${CONTRACTS_BUILD_DIR}" ci > /dev/null || (>&2 echo "[balena_lib_build_contracts]: npm failed installing dependencies" && return 1)
+          NODE_PATH="${CONTRACTS_BUILD_DIR}/node_modules" ${NODE} "${CONTRACTS_BUILD_DIR}/generate-oscontracts.js" > /dev/null
+          if [ -f "${CONTRACTS_OUTPUT_DIR}/${DEVICE_TYPE_SLUG}/balena-os/balena.yml" ]; then
+            echo "${CONTRACTS_OUTPUT_DIR}/${DEVICE_TYPE_SLUG}/balena-os/balena.yml"
+          else
+            >&2 echo "[balena_lib_build_contracts]: Failed to build OS contract for ${DEVICE_TYPE_SLUG}"
+            return 1
           fi
+          # Move newly generated OS contract to location expected later on in the workflow
+          cp "${CONTRACTS_OUTPUT_DIR}/${DEVICE_TYPE_SLUG}/balena-os/balena.yml" "${WORKSPACE}/balena.yml"
 
       - name: Enable development mode in BalenaOS
         if: inputs.os-dev == true

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -404,7 +404,7 @@ jobs:
         if: steps.balena-lib.outputs.is_private == 'true'
         with:
           repository: balena-io/private-contracts
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token-balena-io.outputs.token }}
           path: ${{ github.workspace }}/private-contracts
 
       # Unrolled balena_api_is_dt_private function - https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-api.inc#L424


### PR DESCRIPTION
when building + deploying or a private DT , the check to see if the DT is private fails. This is due to https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-api.inc#L424 using this function: https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-lib.inc#L191 - which uses the jenkins deployTo variable to select the correct api url and token.

Change-type: patch