### PR TITLE
Change finalize-hostapp to tri-state

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -82,11 +82,14 @@ on:
         # We want to deploy the hostapp by default - as a draft if its on a PR, or as final if a new tagged version. This is an input however to allow for manual runs where deploying the hostapp isn't wanted or needed.
         # At some point in the future we want to modify the HUP test suite to use the hostapp as the HUP target, rather than sending the DUT the docker image and doing a HUP using that file
         default: true
+      # The default is "auto" and `check-merge-tests` will determine whether or not to mark the hostapp as final.
+      # True values include case-insensitive true|yes|1|y
+      # False values include case-insensitive false|no|0|n
       finalize-hostapp:
-        description: Whether to finalize a hostApp container image to a balena environment
+        description: Whether to finalize the hostApp (either 'yes' or 'no' or 'auto' to check for tests on tag events)
         required: false
-        type: boolean
-        default: false # The default is "no" - because the `check-merge-tests` will determine whether or not to mark the hostapp as final. This is purely here for a manual override
+        type: string
+        default: auto
       deploy-ami:
         description: Whether to deploy an AMI to AWS
         required: false
@@ -297,7 +300,10 @@ jobs:
       - name: Check test results
         # https://docs.github.com/en/actions/learn-github-actions/expressions#functions
         # this expression checks if test matrix is any variation of empty
-        if: ${{github.event_name == 'push' && contains(fromJSON('["[]","{}","","null"]'), inputs.test_matrix) == false }}
+        if: |
+          inputs.finalize-hostapp == 'auto' &&
+          github.event_name == 'push' && 
+          contains(fromJSON('["[]","{}","","null"]'), inputs.test_matrix) == false
         id: merge-test-result
         env:
           REPO: ${{ inputs.device-repo }}
@@ -639,7 +645,8 @@ jobs:
           RELEASE_VERSION: "${{ steps.balena-lib.outputs.os_version }}"
           BOOTABLE: 1
           TRANSLATION: "v6"
-          FINAL: ${{ steps.merge-test-result.outputs.finalize || inputs.finalize-hostapp }}
+          # Finalize if finalize-hostapp is truthy, or if it is 'auto' and we found passing tests.
+          FINAL: ${{ steps.merge-test-result.outputs.finalize || contains(fromJSON('["true","yes","1","y"]'), inputs.finalize-hostapp) }}
           ESR: "${{ inputs.deploy-esr }}"
           balenaCloudEmail: # TODO: currently trying to use named API key only, its possible email/pw auth no longer has the additional privileges that it used to
           balenaCloudPassword: # TODO: currently trying to use named API key only, its possible email/pw auth no longer has the additional privileges that it used to
@@ -808,7 +815,9 @@ jobs:
       # Note: in the original "yocto-scripts" there were a few checks to ensure that the release was a finalised version, and that it didn't already have a version tag
       # The versions tags are legacy now anyway - so I haven't included that - and we know this will be a finalised release anyway
       - name: Tag ESR release
-        if: inputs.deploy-hostapp == true && inputs.deploy-esr && (steps.merge-test-result.outputs.finalize || inputs.finalize-hostapp)
+        if: |
+          inputs.deploy-hostapp == true && inputs.deploy-esr &&
+          (steps.merge-test-result.outputs.finalize || contains(fromJSON('["true","yes","1","y"]'), inputs.finalize-hostapp))
         env:
           BALENAOS_ACCOUNT: ${{ vars.HOSTAPP_ORG || 'balena_os' }}
           SLUG: "${{ steps.balena-lib.outputs.device_slug }}"


### PR DESCRIPTION
Value can be truthy, or !truthy, or 'auto' to
check for passing tests on tag events.

This allows us to fully disable the auto-finalize for
some customers that don't want to finalize without
manual testing.

Change-type: minor
See: https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/2024.2E7.20ESR/near/451498822