### PR TITLE
Use env vars BALENA_HOST and BALENACLOUD_SSH_URL when provided

### DIFF
--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -55,7 +55,7 @@ jobs:
       test_matrix: >
         {
           "test_suite": ["os","cloud","hup"],
-          "environment": ["bm.balena-dev.com"],
+          "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
           "runs_on": [["self-hosted", "X64", "kvm"]]
         }

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -172,8 +172,8 @@ jobs:
 
     env:
       automation_dir: "${{ github.workspace }}/balena-yocto-scripts/automation"
-      BALENARC_BALENA_URL: ${{ inputs.environment || 'balena-cloud.com' }}
-      API_ENV: ${{ inputs.environment || 'balena-cloud.com' }}
+      BALENARC_BALENA_URL: ${{ vars.BALENA_HOST || inputs.environment || 'balena-cloud.com' }}
+      API_ENV: ${{ vars.BALENA_HOST || inputs.environment || 'balena-cloud.com' }}
 
       # Yocto NFS sstate cache host
       YOCTO_CACHE_HOST: ${{ vars.YOCTO_CACHE_HOST || 'nfs.product-os.io' }}
@@ -1002,9 +1002,9 @@ jobs:
 
     env:
       # Variables provided via the selected GitHub environment
-      BALENACLOUD_API_URL: ${{ matrix.environment }}
-      BALENACLOUD_SSH_PORT: ${{ vars.BALENACLOUD_SSH_PORT || '222' }}
-      BALENACLOUD_SSH_URL: ssh.devices.${{ matrix.environment }}
+      BALENACLOUD_API_URL: ${{ vars.BALENA_HOST || matrix.environment || 'balena-cloud.com' }}
+      BALENACLOUD_SSH_PORT: ${{ vars.BALENACLOUD_SSH_PORT || '22' }}
+      BALENACLOUD_SSH_URL: ${{ vars.BALENACLOUD_SSH_URL || 'ssh.balena-devices.com' }}
 
       # Settings specific to this test run.
       # Generally provided via inputs.test_matrix but sane defaults are also provided.


### PR DESCRIPTION
These currently differ between environments, and we will need to start supporting environment names that are not the same as the balena host.

Change-type: patch