### PR TITLE
revovate: change config to use balena-io template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>balena-os/renovate-config"
+    "github>balena-io/renovate-config"
   ]
 }


### PR DESCRIPTION
in this repo we are using "change-type" commits, but renovate is using the balena-os default which is using "changelog-entry"

Change-type: patch