### PR TITLE
Update Dockerfile_yocto-build-env to install swig

### DIFF
--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk git-core locales zstd liblz4-tool \
                                          texinfo unzip wget xterm cpio file python3 openssh-client iputils-ping iproute2 \
                                          python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
-                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint mesa-common-dev debianutils screen rsync sharutils \
+                                         gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint mesa-common-dev debianutils screen rsync sharutils swig \
                                          && rm -rf /var/lib/apt/lists/*
 
 # Set the locale to UTF-8 for bulding with poky morty


### PR DESCRIPTION
As required by https://github.com/balena-os/balena-iotdin-imx8p/blob/master/layers/meta-balena-imx8mplus/conf/layer.conf#L27

Change-type: patch