### PR TITLE
Add unique unique identifiers to summary job

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -131,7 +131,7 @@ on:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}-${{ inputs.machine }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}-${{ inputs.machine }}-${{ inputs.deploy-environment}}
   # cancel jobs in progress for updated PRs, but not merge or tag events
   cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
@@ -1167,6 +1167,13 @@ jobs:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - machine: ${{ inputs.machine }}
+            environment: ${{ inputs.deploy-environment }}
 
     steps:
       - name: Reject failed jobs


### PR DESCRIPTION
The "All jobs" job is used for branch protection
as it captures the overall success/fail of all
the test matrices and build.

However without a unique name we are unable
to identify the device type in order to mark it as required.

This change adds a single instance matrix
to the build job and as a result will append the machine name and deploy environment in the job name.

Change-type: patch
Depends-on: https://github.com/balena-os/.github/pull/69