### PR TITLE
Fix if condition for checking merge commit test results

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -281,13 +281,9 @@ jobs:
       # If the test_matrix is empty - it means there are no tests for the DT - so don't check tests, and don't finalise, unless manually done with "force-finalize" input
       - name: Check test results
         # https://docs.github.com/en/actions/learn-github-actions/expressions#functions
-        # this expression checks to make sure at least one test suite was provided via either matrix syntax
-        if: |
-          github.event_name == 'push' &&
-          (
-            join(fromJSON(inputs.test_matrix).test_suite) != '' ||
-            join(fromJSON(inputs.test_matrix).include.*.test_suite) != ''
-          ) && inputs.finalize-on-push-if-tests-passed
+        # this expression checks that the test_matrix input is truthy - there is no test_matrix input provided in the device-repo workflow file, test results won't be checked, and 
+        # the release can't be finlized
+        if: github.event_name == 'push' && inputs.test_matrix && inputs.finalize-on-push-if-tests-passed
         id: merge-test-result
         env:
           REPO: ${{ inputs.device-repo }}


### PR DESCRIPTION
The logic for this step was broken - even when no test matrix was provided, it was chekcing for test results, which we don't want (as they won't exist)

Change-type: patch