### PR TITLE
use apt-get to install s4cmd instead of pip

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -562,13 +562,16 @@ jobs:
       ##############################
 
       # TODO: pre-install on self-hosted-runners
+      # Install from debian as using pip like recommended in the repo readme is NOT recommended for externally-managed-environments
+      # Note: s4cmd version in the debian repo and pip is the same (2.1.0)
       # S4cmd is a command-line utility for accessing Amazon S3
       # https://github.com/bloomreach/s4cmd
       - name: Install s4cmd
         if: steps.should-deploy.outputs.deploy
         run: |
-          pip install s4cmd
-          s4cmd --help
+          sudo apt-get update
+          sudo apt-get install -y s4cmd
+          s4cmd --version
 
 
       # login required to pull private balena/balena-img image


### PR DESCRIPTION
using pip to install python packages also installable by debian is not recommended, and leads to errors while trying to do so. Switch to using apt-get to install s4cmd to address this

Change-type: patch