### PR TITLE
remove CLI check if not deploying

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -686,6 +686,7 @@ jobs:
       ##############################
 
       - name: Check Balena CLI installation
+        if: steps.should-deploy.outputs.deploy
         run: |
           balena --version
 


### PR DESCRIPTION
nitpicky fix, we don't use the CLI when not deploying - so no need to check its version

Change-type: patch