### PR TITLE
Restrict runners via yocto label, not 16cpu

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -41,7 +41,7 @@ on:
           [
             "self-hosted",
             "X64",
-            "16cpu"
+            "yocto"
           ]
       device-repo:
         description: balenaOS device repository (owner/repo)


### PR DESCRIPTION
We currently have many `8cpu` runners available that are migrating from Jenkins that we should allow to use for yocto builds.

As long as some runners don't have the `yocto` tag so we don't bottleneck the runner queue for other orgs.

Change-type: patch