### PR TITLE
Give the build job a unique name with the machine and environment

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -159,6 +159,13 @@ jobs:
     runs-on: ${{ fromJSON(inputs.build-runs-on) }}
     environment: ${{ inputs.deploy-environment }}
 
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - machine: ${{ inputs.machine }}
+            environment: ${{ inputs.deploy-environment }}
+
     env:
       automation_dir: "${{ github.workspace }}/balena-yocto-scripts/automation"
       BALENARC_BALENA_URL: ${{ vars.BALENA_HOST || inputs.deploy-environment || 'balena-cloud.com' }}


### PR DESCRIPTION
This allows us to mark specific build-only jobs as required.

Specifically for cases where tests are defined, but those tests may not be marked as required for an ESR branch to merge, so marking 'Yocto / All jobs' as required for that device is not ideal.

Change-type: patch