### PR TITLE
add review-commit-action to wait for approvals on PRT events

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -208,35 +208,18 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     steps:
-      # https://github.com/product-os/flowzone/blob/d92a0f707ca791ea4432306fcb35008848cc9bcb/flowzone.yml#L449-L473
-      - name: Reject unapproved external contributions
-        env:
-          ok_to_test_label: ok-to-test
-          # https://cli.github.com/manual/gh_help_environment
-          GH_DEBUG: "true"
-          GH_PAGER: "cat"
-          GH_PROMPT_DISABLED: "true"
-          GH_REPO: "${{ inputs.device-repo }}"
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-
-          pr_labels="$(gh pr view ${{ github.event.pull_request.number }} --json labels -q .labels[].name)"
-
-          for label in ${pr_labels}
-          do
-            if [[ "$label" =~ "${{ env.ok_to_test_label }}" ]]
-            then
-              gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ env.ok_to_test_label }}"
-              exit 0
-            fi
-          done
-
-          echo "::error::External contributions must be approved with the label '${{ env.ok_to_test_label }}'. \
-            Please contact a member of the organization for assistance."
-          exit 1
+      # Combining pull_request_target workflow trigger with an explicit checkout of an
+      # untrusted PR is a dangerous practice that may lead to repository compromise.
+      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+      # This action requires approvals via reactions for each workflow run.
+      # https://github.com/product-os/review-commit-action
+      - name: Wait for approval on pull_request_target events
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
+        timeout-minutes: 90
+        uses: product-os/review-commit-action@v0.1.4
+        with:
+          poll-interval: '10'
+          allow-authors: false
 
       # this must be done before putting files in the workspace
       # https://github.com/easimon/maximize-build-space


### PR DESCRIPTION
The existing method of using labels allows for
Actions Time Of Check to Time Of Use (TOCTOU) attacks because we do not associate the label with any commit.

This action requires approvals via reactions on a unique comment generated for each workflow run.

Change-type: minor