### PR TITLE
Set explicit permissions at the job level

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -171,16 +171,21 @@ env:
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
-permissions:
-  id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
-  actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
-  pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
+permissions: {}
 
 jobs:
   build:
     name: Build
     runs-on: ${{ fromJSON(inputs.build-runs-on) }}
     environment: ${{ inputs.deploy-environment }}
+
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+    # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+      id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
+      actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
+      pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
 
     env:
       automation_dir: "${{ github.workspace }}/balena-yocto-scripts/automation"


### PR DESCRIPTION
This is the more secure approach that defaults
to lowest possible permissions.

Change-type: patch