### PR TITLE
workflows: yocto-build-deploy: distinguish machine from slug

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -75,6 +75,10 @@ on:
         description: yocto board name
         required: true
         type: string
+      slug:
+        description: Device type slug to deploy to - defaults to machine name
+        required: false
+        type: string
       deploy-environment:
         description: The GitHub environment to deploy to - includes the balena Cloud environment and related vars
         required: false
@@ -175,6 +179,7 @@ concurrency:
 env:
   WORKSPACE: ${{ github.workspace }}
   MACHINE: ${{ inputs.machine }}
+  SLUG: ${{ inputs.slug || inputs.machine }}
   VERBOSE: verbose
   WORKFLOW_NAME: ${{ github.workflow }}
 
@@ -384,7 +389,7 @@ jobs:
 
           ./balena-yocto-scripts/build/build-device-type-json.sh
 
-          device_slug="$(balena_lib_get_slug "${MACHINE}")"
+          device_slug="$(balena_lib_get_slug "${SLUG}")"
           echo "device_slug=${device_slug}" >>"${GITHUB_OUTPUT}"
 
           # As we use this to determine the os version from the device repository - when checking out the repo we need enough fetch depth to get tags
@@ -403,10 +408,10 @@ jobs:
           yocto_scripts_version="$(cd balena-yocto-scripts && head -n1 VERSION)"
           echo "yocto_scripts_version=${yocto_scripts_version}" >>"${GITHUB_OUTPUT}"
 
-          deploy_artifact="$(balena_lib_get_deploy_artifact "${MACHINE}")"
+          deploy_artifact="$(balena_lib_get_deploy_artifact "${SLUG}")"
           echo "deploy_artifact=${deploy_artifact}" >>"${GITHUB_OUTPUT}"
 
-          dt_arch="$(balena_lib_get_dt_arch "${MACHINE}")"
+          dt_arch="$(balena_lib_get_dt_arch "${SLUG}")"
           echo "dt_arch=${dt_arch}" >>"${GITHUB_OUTPUT}"
 
           # Unrolled balena_api_is_dt_private function - https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-api.inc#L424
@@ -724,7 +729,7 @@ jobs:
 
           source "${automation_dir}/include/balena-deploy.inc"
           # https://github.com/balena-os/balena-yocto-scripts/blob/master/automation/include/balena-deploy.inc#L23
-          balena_deploy_artifacts "${{ inputs.machine }}" "${DEPLOY_PATH}" false         
+          balena_deploy_artifacts "${SLUG}" "${DEPLOY_PATH}" false
 
       # gzip the image as that's what the leviathan tests expect
       # and compress the artifacts with tar and zstd to save space
@@ -1121,9 +1126,9 @@ jobs:
           VERSION: "${{ steps.balena-lib.outputs.os_version }}"
         run: |
           if [ "${{ inputs.sign-image }}" = "true" ]; then
-            echo "AMI_NAME=balenaOS-secureboot-${VERSION}-${MACHINE}" | sed 's/+/-/g' >>"${GITHUB_ENV}"
+            echo "AMI_NAME=balenaOS-secureboot-${VERSION}-${SLUG}" | sed 's/+/-/g' >>"${GITHUB_ENV}"
           else
-            echo "AMI_NAME=balenaOS-${VERSION}-${MACHINE}" | sed 's/+/-/g' >>"${GITHUB_ENV}"
+            echo "AMI_NAME=balenaOS-${VERSION}-${SLUG}" | sed 's/+/-/g' >>"${GITHUB_ENV}"
           fi
 
       - name: Login with CLI
@@ -1145,7 +1150,7 @@ jobs:
           config_json=$(mktemp)
           cat << EOF > "${config_json}"
           {
-              "deviceType": "${MACHINE}",
+              "deviceType": "${SLUG}",
               "installer": {
                   "secureboot": true
               }
@@ -1162,7 +1167,7 @@ jobs:
             --fleet "${BALENA_PRELOAD_APP}" \
             --config-network ethernet \
             --version "${HOSTOS_VERSION}"\
-            --device-type "${MACHINE}"\
+            --device-type "${SLUG}"\
             --config "${config_json}"
           rm -rf "${config_json}"
 
@@ -1313,7 +1318,7 @@ jobs:
 
           # Create test fleet
           >&2 echo "Creating ${AMI_TEST_ORG}/${ami_test_fleet}"
-          >&2 balena fleet create "${ami_test_fleet}" --organization "${AMI_TEST_ORG}" --type "${MACHINE}"
+          >&2 balena fleet create "${ami_test_fleet}" --organization "${AMI_TEST_ORG}" --type "${SLUG}"
 
           # Register a key
           mkdir -p "$(dirname "${_key_file}")"

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -35,6 +35,7 @@ balena_deploy_artifacts () {
 	local _yocto_build_deploy
 	local _yocto_licenses_deploy
 	local _slug
+	local _machine
 
 
 	[ ! -f "${_device_type_json}" ] && echo "[balena_deploy_artifacts] Device type JSON not found" && return
@@ -45,7 +46,8 @@ balena_deploy_artifacts () {
 	_deploy_raw_artifact=$(jq --raw-output '.yocto.deployRawArtifact // empty' "${_device_type_json}")
 	_compressed=$(jq --raw-output '.yocto.compressed' "${_device_type_json}")
 	_archive=$(jq --raw-output '.yocto.archive' "$_device_type_json")
-	_yocto_build_deploy="${device_dir}/build/tmp/deploy/images/${_device_type}"
+	_machine=$(jq --raw-output '.yocto.machine' "${_device_type_json}")
+	_yocto_build_deploy="${device_dir}/build/tmp/deploy/images/${_machine}"
 	_yocto_licenses_deploy="${device_dir}/build/tmp/deploy/licenses/"
 	_slug=$(jq --raw-output '.slug' "${_device_type_json}")
 
@@ -56,8 +58,8 @@ balena_deploy_artifacts () {
 
 	cp -v "$_yocto_build_deploy/VERSION" "$_deploy_dir"
 	cp -v "$_yocto_build_deploy/VERSION_HOSTOS" "$_deploy_dir"
-	cp -v "$(readlink --canonicalize "$_yocto_build_deploy/$_image-${_device_type}.manifest")" "$_deploy_dir/$_image-$_device_type.manifest"
-	cp -v "$(readlink --canonicalize "$_yocto_build_deploy/balena-image-$_device_type.docker")" "$_deploy_dir/balena-image.docker"
+	cp -v "$(readlink --canonicalize "$_yocto_build_deploy/$_image-${_machine}.manifest")" "$_deploy_dir/$_image-$_machine.manifest"
+	cp -v "$(readlink --canonicalize "$_yocto_build_deploy/balena-image-$_machine.docker")" "$_deploy_dir/balena-image.docker"
 
 	if [ -d "${_yocto_licenses_deploy}" ]; then
 		tar -czf "${_deploy_dir}/licenses.tar.gz" -C $(dirname "${_yocto_licenses_deploy}") $(basename "${_yocto_licenses_deploy}")

--- a/build/barys
+++ b/build/barys
@@ -198,7 +198,10 @@ fi
 # Get the list of the supported machines out of all the available machine json files
 # (we may have multiple json files describing different machines based on the same balena layers; i.e. imx6 fsl based machines)
 for json in ${DEVICE_TYPES_JSONS}; do
-    SUPPORTED_MACHINES="${SUPPORTED_MACHINES} `jq -r "[.yocto.machine] | sort | .[] | select(. != null)" ${json} 2>/dev/null`" || log ERROR "Please install the 'jq' package before running this script."
+    SUPPORTED_MACHINE="$(jq -r "[.yocto.machine] | sort | .[] | select(. != null)" ${json} 2>/dev/null)" || log ERROR "Please install the 'jq' package before running this script."
+    if ! [[ " ${SUPPORTED_MACHINES} " =~ " ${SUPPORTED_MACHINE} " ]]; then
+        SUPPORTED_MACHINES="${SUPPORTED_MACHINE} ${SUPPORTED_MACHINES}"
+    fi
 done
 
 # Parse arguments
@@ -583,9 +586,11 @@ else
         env MACHINE=$machine bitbake ${IMAGE} $BITBAKEARGS
         if [ $? -eq 0 ]; then
           log "Build for $machine suceeded."
+          break
         else
           log "Build for $machine failed. Check failed log in $BUILD_DIR/tmp/log/cooker/$machine ."
           EXIT_CODE=2 # Fail at the end
+          break
         fi
       done
   done
@@ -605,6 +610,7 @@ else
             log "If build for $machine succeeded, final image should have been generated here:"
             log "   $BUILD_DIR/tmp/deploy/images/$machine/$IMAGE-$machine.$FSTYPE"
         fi
+        break
     done
   done
 fi

--- a/build/barys
+++ b/build/barys
@@ -117,9 +117,9 @@ function help {
     echo -e "\t\t Default: no."
 
     echo -e "\t-t | --templates-path"
-    echo -e "\t\t Provide a custom absolute path to the layer containing custom sample templates."
-    echo -e "\t\t For example, if local.conf.sample and bblayers.conf.sample"
-    echo -e "\t\t are in a /path/to/layer/conf/samples directory, the template path would be /path/to/layer."
+    echo -e "\t\t Provide a custom path to the local.conf.sample"
+    echo -e "\t\t and bblayers.conf.sample templates directory."
+    echo -e "\t\t For example, /path/to/layer/conf/samples/mytemplate"
     echo -e "\t\t Default: Use the ones in the integration BSP layer."
 
     echo -e "\t--rm-work"
@@ -303,8 +303,8 @@ while [[ $# -ge 1 ]]; do
             if [ -z "$2" ]; then
                 log ERROR "\"$1\" argument is invalid."
             fi
-            LAYERSCONF_PATH=$2
-            log WARN "LAYERSCONF_PATH: $LAYERSCONF_PATH"
+            TEMPLATECONF_PATH=$2
+            log WARN "TEMPLATECONF_PATH: $TEMPLATECONF_PATH"
             shift
             ;;
         -l|--log)
@@ -392,8 +392,8 @@ while [[ $# -ge 1 ]]; do
             read -p "Custom templates path? yes/[no] " yn
             case $yn in
                 [Yy]* )
-                    read -p "Templated path? " LAYERSCONF_PATH
-                    if [ -z "$LAYERSCONF_PATH" ]; then
+                    read -p "Templates path? " TEMPLATECONF_PATH
+                    if [ -z "$TEMPLATECONF_PATH" ]; then
                         log ERROR "Provided path is invalid."
                     fi
                     ;;
@@ -446,7 +446,7 @@ if [ "z$LOG" == "zyes" ]; then
     echo "Compressed image? $COMPRESS" >> $LOGFILE
     echo "Shared downloads directory: $SHARED_DOWNLOADS" >> $LOGFILE
     echo "Shared sstate directory: $SHARED_SSTATE" >> $LOGFILE
-    echo "Custom templates path: $LAYERSCONF_PATH" >> $LOGFILE
+    echo "Custom templates path: $TEMPLATECONF_PATH" >> $LOGFILE
     echo "Development image? $DEVELOPMENT_IMAGE" >> $LOGFILE
     echo "Forced supervisor image release version: $SUPERVISOR_VERSION" >> $LOGFILE
     echo "Inherit rm_work? $RM_WORK" >> $LOGFILE
@@ -460,25 +460,29 @@ if [ "x$REMOVEBUILD" == "xyes" ]; then
     rm -rf $SCRIPTPATH/../../$BUILD_DIR
 fi
 
-if [ -z "${LAYERSCONF_PATH}" ] ; then
+if [ -z "${TEMPLATECONF_PATH}" ] ; then
     # Look on the BSP integration layer meta-balena-*
-    LAYERSCONF_PATH="${SCRIPTPATH}/../../layers/meta-balena"*
+    TEMPLATECONF_PATH=$(dirname $(find "${SCRIPTPATH}/../../layers/meta-balena"* -name bblayers.conf.sample))
 else
-    if [ "${LAYERSCONF_PATH#/}" = "${LAYERSCONF_PATH}" ]; then
-        if [ "${LAYERSCONF_PATH#layers/}" != "${LAYERSCONF_PATH}" ]; then
-            LAYERSCONF_PATH="${SCRIPTPATH}/../../${LAYERSCONF_PATH}"
+    if [ "${TEMPLATECONF_PATH#/}" = "${TEMPLATECONF_PATH}" ]; then
+        # Does not start with /
+        if [ "${TEMPLATECONF_PATH#layers/}" != "${TEMPLATECONF_PATH}" ]; then
+            # starts with layers/
+            TEMPLATECONF_PATH="${SCRIPTPATH}/../../${TEMPLATECONF_PATH}"
         else
-            log ERROR "The custom templates layer path needs to be either absolute or relative to the build directoty, i.e layers/meta-custom. "
+            log ERROR "The custom templates path needs to be either absolute or relative to the build directoty, i.e layers/meta-custom/conf/samples/mytemplate. "
         fi
     fi
 fi
-TEMPLATECONF_PATH=$(dirname $(find ${LAYERSCONF_PATH} -name bblayers.conf.sample))
+
+# make sure it contains templates
+TEMPLATECONF_PATH=$(dirname $(find ${TEMPLATECONF_PATH} -name bblayers.conf.sample))
 if [ "$(echo "${TEMPLATECONF_PATH}" | wc -w)" -gt "1" ]; then
     log ERROR "Multiple bblayers.conf.sample files found in BSP integration layer. Please provide a custom path."
 fi
 
 # Configure build
-$SCRIPTPATH/generate-conf-notes.sh "${TEMPLATECONF_PATH%/samples}" ${DEVICE_TYPES_JSONS}
+$SCRIPTPATH/generate-conf-notes.sh "${TEMPLATECONF_PATH}" ${DEVICE_TYPES_JSONS}
 
 export TEMPLATECONF="${TEMPLATECONF_PATH}"
 # scarthgap expects templates to be contained in a subdirectory inside templates/

--- a/build/generate-conf-notes.sh
+++ b/build/generate-conf-notes.sh
@@ -13,7 +13,7 @@ CONF=$1             # CONFNAME file directory location
 CONFNAME="conf-notes.txt"
 
 # The conf directory is yocto version specific
-CONF=$CONF/samples
+CONF="$(dirname $(find "$CONF" -name "bblayers.conf.sample"))"
 
 # Checks
 


### PR DESCRIPTION
Machine refers to the Yocto machine configuration, while slug refers to the balenaCloud device type.

This allows to build the same machine but deploy to a different device type.

Change-type: patch