### PR TITLE
generate-oscontracts: remove sw.os-image selector

### DIFF
--- a/build/contracts/blueprints/os-contracts.yaml
+++ b/build/contracts/blueprints/os-contracts.yaml
@@ -1,6 +1,5 @@
 selector:
   sw.os: 1
-  sw.os-image: 1
   hw.device-type: 1
   arch.sw: 1
 output:


### PR DESCRIPTION
https://github.com/balena-io/contracts/commit/2903ca430d32ba59fc662ed2a646fcb2aac6e6a0 removed the sw.os-image contract. Removing it from the oscontract blueprint to fix build errors

Change-type: patch