### PR TITLE
Unset the new environment inputs until they have been deployed

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -88,22 +88,22 @@ on:
         description: The balena environment to use for yocto build - includes the related vars and secrets
         required: false
         type: string
-        default: balena-cloud.com
+        # default: balena-cloud.com
       hostapp-deploy-environment:
         description: The balena environment to use for hostApp deployment - includes the related vars and secrets
         required: false
         type: string
-        default: balena-cloud.com
+        # default: balena-cloud.com
       source-mirror-environment:
         description: The AWS environment to use for the S3 source mirror - includes related vars and OIDC role(s)
         required: false
         type: string
-        default: ''
+        # default: balena-production.us-east-1
       s3-deploy-environment:
         description: The AWS environment to use for the S3 and AMI deployments - includes related vars and OIDC role(s)
         required: false
         type: string
-        default: ''
+        # default: balena-production.us-east-1
       # This input exists because we want the option to not auto-finalise for some device types, even if they have tests and those tests pass - for example some custom device types, the customer doesn't want new releases published until they green light it
       finalize-on-push-if-tests-passed:
         description: Whether to finalize a hostApp container image to a balena environment, if tests pass.


### PR DESCRIPTION
By setting defaults here we are overriding values that may have been set at the device level via deploy-environment.

For now leave them blank until we have rolled out the new environments to all the repositories.

See: https://balena.fibery.io/Work/Project/Separate-balenaOS-signing-environments-from-deploy-environments-1049
See: https://github.com/balena-os/balena-yocto-scripts/pull/481