### PR TITLE
Rename build environment to signing environment

### DIFF
--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -55,7 +55,7 @@ jobs:
     with:
       machine: genericx86-64-ext
       build-environment: balena-staging.com
-      hostapp-deploy-environment: balena-staging.com
+      deploy-environment: balena-staging.com
       s3-deploy-environment: balena-staging.com
       source-mirror-environment: balena-staging.com
       # device-repo and device-repo-ref inputs should not be provided on device repos

--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -54,9 +54,7 @@ jobs:
     secrets: inherit
     with:
       machine: genericx86-64-ext
-      build-environment: balena-staging.com
       deploy-environment: balena-staging.com
-      source-mirror-environment: balena-staging.com
       # device-repo and device-repo-ref inputs should not be provided on device repos
       device-repo: balena-os/balena-intel
       device-repo-ref: master

--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -56,7 +56,6 @@ jobs:
       machine: genericx86-64-ext
       build-environment: balena-staging.com
       deploy-environment: balena-staging.com
-      s3-deploy-environment: balena-staging.com
       source-mirror-environment: balena-staging.com
       # device-repo and device-repo-ref inputs should not be provided on device repos
       device-repo: balena-os/balena-intel

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -94,11 +94,6 @@ on:
         required: false
         type: string
         # default: balena-production.us-east-1
-      s3-deploy-environment:
-        description: The AWS environment to use for the S3 and AMI deployments - includes related vars and OIDC role(s)
-        required: false
-        type: string
-        # default: balena-production.us-east-1
       # This input exists because we want the option to not auto-finalise for some device types, even if they have tests and those tests pass - for example some custom device types, the customer doesn't want new releases published until they green light it
       finalize-on-push-if-tests-passed:
         description: Whether to finalize a hostApp container image to a balena environment, if tests pass.
@@ -1212,7 +1207,7 @@ jobs:
     # - AWS_IAM_ROLE: AWS IAM role to assume for S3 image deployment, AMI deployment
     # - AWS_S3_BUCKET: AWS S3 bucket for image deployment, and AMI deployment
     # - AWS_S3_SSE_ALGORITHM: AWS S3 server-side encryption algorithm
-    environment: ${{ inputs.s3-deploy-environment || inputs.deploy-environment }}
+    environment: ${{ inputs.deploy-environment }}
 
     env:  
       # Include a number of similar variable keys to allow for flexibility in the environment and backwards compatibility
@@ -1380,7 +1375,7 @@ jobs:
     # - AWS_S3_SSE_ALGORITHM: AWS S3 server-side encryption algorithm
     # This environment should contain the following secrets:
     # - BALENA_API_DEPLOY_KEY: Balena API deploy key with access to the balena_os/cloud-config-* fleets
-    environment: ${{ inputs.s3-deploy-environment || inputs.deploy-environment }}
+    environment: ${{ inputs.deploy-environment }}
 
     env:  
       # Include a number of similar variable keys to allow for flexibility in the environment and backwards compatibility

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -80,17 +80,12 @@ on:
         required: false
         type: string
       deploy-environment:
-        description: Deprecated - use hostapp-deploy-environment instead
+        description: The balena environment to use for hostApp deployment - includes the related vars and secrets
         required: false
         type: string
         default: balena-cloud.com
       build-environment:
-        description: The balena environment to use for yocto build - includes the related vars and secrets
-        required: false
-        type: string
-        # default: balena-cloud.com
-      hostapp-deploy-environment:
-        description: The balena environment to use for hostApp deployment - includes the related vars and secrets
+        description: The bitbake environment to use for yocto build - includes the related vars and secrets
         required: false
         type: string
         # default: balena-cloud.com
@@ -189,7 +184,7 @@ on:
 # Note that we do not use github.ref here, as PRs from forks will have a
 # ref of 'refs/heads/master' and collide with each other. Instead, we use github.head_ref
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.machine }}-${{ inputs.hostapp-deploy-environment || inputs.deploy-environment }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.machine }}-${{ inputs.deploy-environment }}
   # Cancel jobs in-progress for open PRs, but not merged or closed PRs, by checking for the merge ref.
   # Note that for pull_request_target events (PRs from forks), the github.ref value is
   # usually 'refs/heads/master' so we can't rely on that to determine if it is a merge event or not.
@@ -245,7 +240,7 @@ jobs:
     # - BALENA_HOST
     # This environment requires the following secrets:
     # - BALENA_API_DEPLOY_KEY - used to authenticate with the balena API
-    environment: ${{ inputs.hostapp-deploy-environment || inputs.deploy-environment || 'balena-cloud.com' }}
+    environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
 
     env:
       automation_dir: "${{ github.workspace }}/balena-yocto-scripts/automation"
@@ -931,7 +926,7 @@ jobs:
     # - HOSTAPP_ORG
     # This environment should contain the following secrets:
     # - BALENA_API_DEPLOY_KEY
-    environment: ${{ inputs.hostapp-deploy-environment || inputs.deploy-environment }}
+    environment: ${{ inputs.deploy-environment }}
 
     env:
       BALENARC_BALENA_URL: ${{ vars.BALENA_HOST || vars.BALENARC_BALENA_URL || 'balena-cloud.com' }}
@@ -2128,7 +2123,7 @@ jobs:
       matrix:
         include:
           - machine: ${{ inputs.machine }}
-            environment: ${{ inputs.hostapp-deploy-environment || inputs.deploy-environment }}
+            environment: ${{ inputs.deploy-environment }}
 
     steps:
       - name: Reject failed jobs

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -84,11 +84,11 @@ on:
         required: false
         type: string
         default: balena-cloud.com
-      build-environment:
-        description: The bitbake environment to use for yocto build - includes the related vars and secrets
+      signing-environment:
+        description: The signing environment to use for the bitbake build - includes the related vars and secrets
         required: false
         type: string
-        # default: balena-cloud.com
+        default: ''
       source-mirror-environment:
         description: The AWS environment to use for the S3 source mirror - includes related vars and OIDC role(s)
         required: false
@@ -264,6 +264,7 @@ jobs:
       should_finalize: ${{ steps.merge-test-result.outputs.finalize == 'true' || inputs.force-finalize }}
       is_esr: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')) || (github.event_name == 'workflow_dispatch' && startsWith(github.ref_name, '20')) }}
       deploy_path: ${{ github.workspace }}/deploy/${{ steps.balena-lib.outputs.device_slug }}/${{ steps.balena-lib.outputs.os_version }}
+      balena_host: ${{ env.BALENARC_BALENA_URL }}
 
     steps:
       # Generate an app installation token that has access to
@@ -505,7 +506,7 @@ jobs:
     # - SIGN_API_KEY
     # - SIGN_KMOD_KEY_APPEND
     # - YOCTO_SSH_PRIVATE_KEY_B64: used to pull private yocto sources from within the same organization
-    environment: ${{ inputs.build-environment || inputs.deploy-environment }}
+    environment: ${{ inputs.signing-environment || inputs.deploy-environment }}
 
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
@@ -521,7 +522,7 @@ jobs:
       # https://docs.yoctoproject.org/3.1.21/overview-manual/overview-manual-concepts.html#user-configuration
       # Create an autobuilder configuration file that is loaded before local.conf
       AUTO_CONF_FILE: "${{ github.workspace }}/build/conf/auto.conf"
-      BALENARC_BALENA_URL: ${{ vars.BALENA_HOST || 'balena-cloud.com' }}
+      BALENARC_BALENA_URL: ${{ needs.balena-lib.outputs.balena_host }}
       DEPLOY_PATH: ${{ github.workspace }}/deploy
 
     defaults:


### PR DESCRIPTION
Tested with signing environments [here](https://github.com/balena-os/balena-generic/pull/566).

This simplifies the inputs, and keeps them closer to the current device repo workflows. The only change required will be on the 3 secure boot repositories to provide a signing environment ([example](https://github.com/balena-os/balena-generic/pull/566/files)).