### PR TITLE
workflows: yocto-build-deploy: setup AWS authentication for tests

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1905,6 +1905,7 @@ jobs:
     needs:
       - approved-commit
       - balena-lib
+      - source-mirror-setup
       - build
     # Specify the runner type in the test_matrix input.
     # QEMU workers need ["self-hosted", "X64", "kvm"] or ["self-hosted", "ARM64", "kvm"] runners.
@@ -2079,6 +2080,16 @@ jobs:
           echo "QEMU_SECUREBOOT=1" >> "${GITHUB_ENV}"
           echo "FLASHER_SECUREBOOT=1" >> "${GITHUB_ENV}"
           echo "QEMU_MEMORY=4G" >> "${GITHUB_ENV}"
+
+      # https://github.com/aws-actions/configure-aws-credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ needs.source-mirror-setup.outputs.aws-iam-role }}
+          role-session-name: github-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: ${{ needs.source-mirror-setup.outputs.aws-region }}
+          # https://github.com/orgs/community/discussions/26636#discussioncomment-3252664
+          mask-aws-account-id: false
 
       # https://github.com/balena-os/leviathan/blob/master/action.yml
       - name: BalenaOS Leviathan Tests


### PR DESCRIPTION
The secure boot test for signed kernel modules, when run for private device types, needs to be able to download kernel headers from an authenticated S3 bucket, at least until the assets are moved to using web resources.

Change-type: patch