### PR TITLE
AMI deploy: parameterise test org + fleet for AMI test

### DIFF
--- a/.github/workflows/genericx86-64-ext.yml
+++ b/.github/workflows/genericx86-64-ext.yml
@@ -53,11 +53,12 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     secrets: inherit
     with:
-      machine: genericx86-64-ext
-      deploy-environment: balena-staging.com
+      machine: generic-amd64
+      deploy-environment: balena-staging.com # USE BALENA GENERIC TO TEST THIS PR
       # device-repo and device-repo-ref inputs should not be provided on device repos
-      device-repo: balena-os/balena-intel
+      device-repo: balena-os/balena-generic # USE BALENA GENERIC TO TEST THIS PR
       device-repo-ref: master
+      deploy-ami: true
       # Use qemu workers for testing
       test_matrix: >
         {

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1363,7 +1363,8 @@ jobs:
   ami-deploy:
     name: Deploy AMI
     runs-on: ${{ fromJSON(inputs.build-runs-on) }}
-    if: inputs.deploy-ami && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    ## ENSURE THIS RUNS ON EVERY PR FOR TESTING - REMOVE THIS BEFORE MERGE
+    if: inputs.deploy-ami
     needs:
       - approved-commit
       - build
@@ -1650,24 +1651,27 @@ jobs:
         run: |
           aws s3 rm "${S3_IMG_URL}"
 
-      - name: Setup AMI test fleet
-        id: ami-test-fleet
+      - name: Setup AMI test Device
+        id: ami-test-device
         env:
           HOSTOS_VERSION: "${{ needs.balena-lib.outputs.os_version }}"
-          AMI_TEST_ORG: testbot
           AMI_TEST_DEV_MODE: true
         run: | 
           key_file="${HOME}/.ssh/id_ed25519"
 
+          # Create a fleet with randomised name, using the name as the key id so we can identify the correct key to delete at the end of the test
           ami_test_fleet=$(openssl rand -hex 4)
+          # Export this as an output, so in the teardown we can delete it
+          echo "ami_test_fleet=${ami_test_fleet}" >>"${GITHUB_OUTPUT}"
+
           config_json=$(mktemp)
           echo "config_json=${config_json}" >>"${GITHUB_OUTPUT}"
-
+          
           # Create test fleet
-          >&2 echo "Creating ${AMI_TEST_ORG}/${ami_test_fleet}"
-          >&2 balena fleet create "${ami_test_fleet}" --organization "${AMI_TEST_ORG}" --type "${SLUG}"
+          >&2 echo "Creating ${ami_test_fleet}"
+          >&2 balena fleet create "${ami_test_fleet}" --type "${SLUG}"
 
-          # Register a key
+          # Register an SSH key
           mkdir -p "$(dirname "${_key_file}")"
           ssh-keygen -t ed25519 -N "" -q -f "${key_file}"
           # shellcheck disable=SC2046
@@ -1675,7 +1679,7 @@ jobs:
           >&2 ssh-add
           balena key add "${ami_test_fleet}" "${key_file}.pub"
 
-          uuid=$(balena device register "${AMI_TEST_ORG}/${ami_test_fleet}" | awk '{print $4}')
+          uuid=$(balena device register "${ami_test_fleet}" | awk '{print $4}')
           >&2 echo "Pre-registered device with UUID ${uuid}"
           echo "uuid=${uuid}" >>"${GITHUB_OUTPUT}"
 
@@ -1696,14 +1700,13 @@ jobs:
                   exit 1
               fi
           fi
-          echo "fleet=${AMI_TEST_ORG}/${ami_test_fleet}" >>"${GITHUB_OUTPUT}"
 
       - name: Test AMI image
         id: ami-test
         env:
           IMAGE: ${{ env.DEPLOY_PATH }}/image/balena.img
-          UUID: "${{ steps.ami-test-fleet.outputs.uuid }}"
-          CONFIG_JSON: "${{ steps.ami-test-fleet.outputs.config_json }}"
+          UUID: "${{ steps.ami-test-device.outputs.uuid }}"
+          CONFIG_JSON: "${{ steps.ami-test-device.outputs.config_json }}"
           AWS_SUBNET_ID: ${{ env.AWS_SUBNET_ID }}
           AWS_SECURITY_GROUP_ID: ${{ env.AWS_SECURITY_GROUP_ID }}
         run: |
@@ -1762,14 +1765,17 @@ jobs:
         run: |
           aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
 
-      - name: Clean up test fleet
+      - name: Clean up test device
         continue-on-error: true
         if: always()
         env: 
-          FLEET: "${{ steps.ami-test-fleet.outputs.fleet }}"
+          TEST_DEVICE_UUID: "${{ steps.ami-test-device.outputs.uuid }}"
+          FLEET: "${{ steps.ami-test-device.outputs.ami_test_fleet }}"
         run: |
           [ -z "${FLEET}" ] && exit 0
           balena fleet rm "${FLEET}" --yes || true
+          
+          # Delete SSH key used in test
           _key_id=$(balena ssh-key list | grep "${FLEET#*/}" | awk '{print $1}')
           balena ssh-key rm "${_key_id}" --yes || true
         
@@ -1875,7 +1881,8 @@ jobs:
 
         # Tear down any AMI's created in the case of a failure - to leave a clean slate for the next run
       - name: Clean up AMI images on failure
-        if: failure()
+        # DRAFT - ALWAYS CLEAN UP IMAGE AT THE END - WE DON@T ACTUALLY WANT TO PUBLISH ANYTHING WHILE TESTING THE PR
+        if: always() 
         run: |
           image_id=$(aws ec2 describe-images \
               --filters "Name=name,Values=${AMI_NAME}" \

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -967,6 +967,7 @@ jobs:
         env:
           # renovate: datasource=github-releases depName=balena-io/balena-cli
           BALENA_CLI_VERSION: v21.1.9
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         with:
           # balena CLI version to install
           cli-version: ${{ env.BALENA_CLI_VERSION }}
@@ -1483,6 +1484,7 @@ jobs:
         env:
           # renovate: datasource=github-releases depName=balena-io/balena-cli
           BALENA_CLI_VERSION: v21.1.9
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         with:
           # balena CLI version to install
           cli-version: ${{ env.BALENA_CLI_VERSION }}
@@ -1496,6 +1498,7 @@ jobs:
           AMI_SECUREBOOT: "${{ inputs.sign-image }}"
           BALENA_PRELOAD_APP: "balena_os/cloud-config-${{ needs.balena-lib.outputs.dt_arch }}"
           HOSTOS_VERSION: "${{ needs.balena-lib.outputs.os_version }}"
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         run: |          
           config_json=$(mktemp)
           cat << EOF > "${config_json}"
@@ -1526,6 +1529,7 @@ jobs:
           IMAGE: ${{ env.DEPLOY_PATH }}/image/balena.img
           BALENA_PRELOAD_APP: "balena_os/cloud-config-${{ needs.balena-lib.outputs.dt_arch }}"
           BALENA_PRELOAD_COMMIT: current
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         run: |
           echo "* Adding the preload app"
           balena preload \
@@ -1656,6 +1660,7 @@ jobs:
         env:
           HOSTOS_VERSION: "${{ needs.balena-lib.outputs.os_version }}"
           AMI_TEST_DEV_MODE: true
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         run: | 
           key_file="${HOME}/.ssh/id_ed25519"
 
@@ -1709,6 +1714,7 @@ jobs:
           CONFIG_JSON: "${{ steps.ami-test-device.outputs.config_json }}"
           AWS_SUBNET_ID: ${{ env.AWS_SUBNET_ID }}
           AWS_SECURITY_GROUP_ID: ${{ env.AWS_SECURITY_GROUP_ID }}
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         run: |
           # Default to a Nitro instance for TPM support
           _ami_instance_type="m5.large"
@@ -1771,6 +1777,7 @@ jobs:
         env: 
           TEST_DEVICE_UUID: "${{ steps.ami-test-device.outputs.uuid }}"
           FLEET: "${{ steps.ami-test-device.outputs.ami_test_fleet }}"
+          BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
         run: |
           [ -z "${FLEET}" ] && exit 0
           balena fleet rm "${FLEET}" --yes || true


### PR DESCRIPTION
Allows using vars to set the org + fleet name for use in AMI tests, instead of hard coding and dynamically creating fleets.

This is to make management of permissions simpler

Change-type: patch