### PR TITLE
build/barys: Fix builds for older Poky variants

### DIFF
--- a/build/barys
+++ b/build/barys
@@ -531,7 +531,7 @@ for pair in $ADDITIONAL_VARIABLES; do
 done
 
 DEVICE_LAYER_CONF=$(ls ${SCRIPTPATH}/../../layers/meta-balena-*/conf/layer.conf)
-if ls "${SCRIPTPATH}/../../layers/meta-balena/meta-*-${OLD_SYNTAX_RELEASES[0]}" >/dev/null 2>&1; then
+if ls ${SCRIPTPATH}/../../layers/meta-balena/meta-*-${OLD_SYNTAX_RELEASES[0]} >/dev/null 2>&1; then
     for poky_release in "${OLD_SYNTAX_RELEASES[@]}"; do
         if grep -q -i "LAYERSERIES_COMPAT.*$poky_release" ${DEVICE_LAYER_CONF}; then
             log "Release $poky_release not supported by device integration layer, will revert meta-balena-common syntax."


### PR DESCRIPTION
Commit 8d9f26fb switched to using the wildcard * char inside quotes, which makes ls fail to find the intended directory and thus all builds for older Poky revisions fail. We can fix this by removing the quotes.

Change-type: patch