### PR TITLE
AMI deploy: parameterise test org + use testing api key

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1423,6 +1423,7 @@ jobs:
       AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET || vars.S3_BUCKET }}
       AWS_S3_SSE_ALGORITHM: ${{ vars.SOURCE_MIRROR_S3_SSE_ALGORITHM || vars.AWS_S3_SSE_ALGORITHM || vars.S3_SSE_ALGORITHM || vars.SSE_ALGORITHM || vars.SSE || 'AES256' }}
 
+      BALENARC_BALENA_URL: ${{ vars.BALENA_HOST }}
       DEPLOY_PATH: ${{ github.workspace }}/deploy
 
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
@@ -1533,11 +1534,11 @@ jobs:
           # balena CLI version to install
           cli-version: ${{ env.BALENA_CLI_VERSION }}
           # balenaCloud API token to login automatically
-          balena-token: ${{ secrets.BALENA_API_DEPLOY_KEY }}
+          balena-token: ${{ secrets.BALENA_API_TEST_KEY }}
 
       - name: Configure AMI installer image
         env:
-          BALENACLI_TOKEN: ${{ secrets.BALENA_API_DEPLOY_KEY }}
+          BALENACLI_TOKEN: ${{ secrets.BALENA_API_TEST_KEY }}
           IMAGE: ${{ env.DEPLOY_PATH }}/image/balena.img
           AMI_SECUREBOOT: "${{ inputs.sign-image }}"
           BALENA_PRELOAD_APP: "balena_os/cloud-config-${{ needs.balena-lib.outputs.dt_arch }}"
@@ -1701,7 +1702,7 @@ jobs:
         id: ami-test-fleet
         env:
           HOSTOS_VERSION: "${{ needs.balena-lib.outputs.os_version }}"
-          AMI_TEST_ORG: testbot
+          AMI_TEST_ORG: ${{ vars.AMI_TEST_ORG || 'testbot'}}
           AMI_TEST_DEV_MODE: true
         run: | 
           key_file="${HOME}/.ssh/id_ed25519"

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1536,38 +1536,6 @@ jobs:
           # balenaCloud API token to login automatically
           balena-token: ${{ secrets.BALENA_API_TEST_KEY }}
 
-      - name: Configure AMI installer image
-        env:
-          BALENACLI_TOKEN: ${{ secrets.BALENA_API_TEST_KEY }}
-          IMAGE: ${{ env.DEPLOY_PATH }}/image/balena.img
-          AMI_SECUREBOOT: "${{ inputs.sign-image }}"
-          BALENA_PRELOAD_APP: "balena_os/cloud-config-${{ needs.balena-lib.outputs.dt_arch }}"
-          HOSTOS_VERSION: "${{ needs.balena-lib.outputs.os_version }}"
-        run: |          
-          config_json=$(mktemp)
-          cat << EOF > "${config_json}"
-          {
-              "deviceType": "${SLUG}",
-              "installer": {
-                  "secureboot": true
-              }
-          }
-          EOF
-
-          if [ -z "${AMI_SECUREBOOT}" ] || [ "${AMI_SECUREBOOT}" = "false" ]; then
-              exit 0
-          fi
-
-          echo "* Configuring installer image"
-          balena os configure "${IMAGE}"\
-            --debug \
-            --fleet "${BALENA_PRELOAD_APP}" \
-            --config-network ethernet \
-            --version "${HOSTOS_VERSION}"\
-            --device-type "${SLUG}"\
-            --config "${config_json}"
-          rm -rf "${config_json}"
-
       - name: Preload AMI install image
         env:
           IMAGE: ${{ env.DEPLOY_PATH }}/image/balena.img
@@ -1733,7 +1701,8 @@ jobs:
               _dev_mode="";
           fi
 
-          >&2 balena config generate --network ethernet --version "${HOSTOS_VERSION}" --device "${uuid}" --appUpdatePollInterval 5 --output "${config_json}" "${_dev_mode}"
+
+          >&2 balena config generate --network ethernet --version "${HOSTOS_VERSION}" --device "${uuid}" --appUpdatePollInterval 5 --output "${config_json}" ${_dev_mode}
           if [ ! -f "${config_json}" ]; then
             echo "Unable to generate configuration"
             exit 1


### PR DESCRIPTION
This PR:
- Fixes non-secureboot AMI deploys 
- Disables secureboot AMI publishing - as this no longer works due to incompatibilities with secureboot and preloading: https://balena.fibery.io/Work/Project/Re-implement-secureboot-enabled-AMI's-1460