### PR TITLE
Remove the old grep for build errors

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -754,10 +754,6 @@ jobs:
             -s "${SHARED_BUILD_DIR}" \
             -g "${BARYS_ARGUMENTS_VAR}" | tee balena-build.log
 
-          if grep -R "ERROR: " build/tmp/log/*; then
-            exit 1
-          fi
-
           if ! grep -q "Build for ${{ inputs.machine }} suceeded" balena-build.log; then
             exit 1
           fi


### PR DESCRIPTION
This grep has started to catch file strings in the cooker logs, even on success, so instead just rely on the success message in the second grep of balena build logs.

See: [#balena-io/os/devices > new imx8mmebcrs16a1 device type @ 💬](https://balena.zulipchat.com/#narrow/channel/360838-balena-io.2Fos.2Fdevices/topic/new.20imx8mmebcrs16a1.20device.20type/near/518678926)