### PR TITLE
Make hostapp-deploy depend on a successful s3-deploy

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -917,6 +917,7 @@ jobs:
       - approved-commit
       - build
       - balena-lib
+      - s3-deploy
 
     # This environment should contain the following variables:
     # - BALENA_HOST


### PR DESCRIPTION
If something failed on S3 upload, we do not want to deploy the hostapp as it will likely need to be invalidated.

This order will change when we move to web resources, and uploads depend on the hostapp creation.

Change-type: minor