### PR TITLE
Use the leviathan action from the submodule in meta-balena 

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -2184,7 +2184,9 @@ jobs:
 
       # https://github.com/balena-os/leviathan/blob/master/action.yml
       - name: BalenaOS Leviathan Tests
-        uses: balena-os/leviathan@b3021f1a0eadb72be7a855f585489872cb92f889 # v2.34.4
+        # Use the leviathan action from the submodule in meta-balena
+        # Using the submodule version maintains backward compatibility and restricts version drift  
+        uses: ./layers/meta-balena/tests/leviathan
         env:
           WORKSPACE: "${{ env.LEVIATHAN_WORKSPACE }}"
           # BALENA_API_TEST_KEY is a secret that should be specific to the runtime environment


### PR DESCRIPTION
The action currently has dependencies on the leviathan base
project so we need to keep them aligned for now.

See: https://balena.fibery.io/Work/Improvement/Update-yocto-scripts-workflow-to-use-leviathan-submodule-2944