### PR TITLE
prepare deflate artifacts even on PRs

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -881,7 +881,6 @@ jobs:
       # Deflate files are the main image artifact for S3 / webresource deploy
       # is they are used by the img-maker and os download endpoints.
       - name: Prepare deflate files
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || inputs.force-finalize
         env:
           HELPER_IMAGE: balena/balena-img:6.20.26
         run: |


### PR DESCRIPTION
On PRs if there are no deflate files generated, the subsequent encrypt step will fail (it is run only for private DTs). Rather than add any further complication to that step, its cleaner to just prepare the deflate files regardless. Especially as we might be adding them to PR draft releases in the future anyway. The time cost is low for this step anyway.

Change-type: patch