### PR TITLE
Add CycloneDX SBOM and VEX generation

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -945,7 +945,7 @@ jobs:
             ${{ env.S3_DEPLOY_PATH }}/VERSION*
             ${{ env.S3_DEPLOY_PATH }}/*.manifest
             ${{ env.S3_DEPLOY_PATH }}/licenses.tar.gz
-            ${{ env.S3_DEPLOY_PATH }}/sbom+vex.json.zip
+            ${{ env.S3_DEPLOY_PATH }}/cyclonedx/*/*.json
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz.enc
             ${{ env.S3_DEPLOY_PATH }}/secure-boot-lock.tar.gz.enc
@@ -1272,7 +1272,7 @@ jobs:
             ${{ env.DEPLOY_PATH }}/compressed*/*.deflate
             ${{ env.DEPLOY_PATH }}/kernel_modules_headers.tar.gz
             ${{ env.DEPLOY_PATH }}/licenses.tar.gz
-            ${{ env.DEPLOY_PATH }}/sbom+vex.json.zip
+            ${{ env.DEPLOY_PATH }}/cyclonedx/*/*.json
             ${{ env.DEPLOY_PATH }}/secure-boot-lock.tar.gz
 
   ##############################

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -945,6 +945,7 @@ jobs:
             ${{ env.S3_DEPLOY_PATH }}/VERSION*
             ${{ env.S3_DEPLOY_PATH }}/*.manifest
             ${{ env.S3_DEPLOY_PATH }}/licenses.tar.gz
+            ${{ env.S3_DEPLOY_PATH }}/sbom+vex.json.zip
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz.enc
             ${{ env.S3_DEPLOY_PATH }}/secure-boot-lock.tar.gz.enc
@@ -1271,6 +1272,7 @@ jobs:
             ${{ env.DEPLOY_PATH }}/compressed*/*.deflate
             ${{ env.DEPLOY_PATH }}/kernel_modules_headers.tar.gz
             ${{ env.DEPLOY_PATH }}/licenses.tar.gz
+            ${{ env.DEPLOY_PATH }}/sbom+vex.json.zip
             ${{ env.DEPLOY_PATH }}/secure-boot-lock.tar.gz
 
   ##############################

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -49,6 +49,8 @@ balena_deploy_artifacts () {
 	_machine=$(jq --raw-output '.yocto.machine' "${_device_type_json}")
 	_yocto_build_deploy="${device_dir}/build/tmp/deploy/images/${_machine}"
 	_yocto_licenses_deploy="${device_dir}/build/tmp/deploy/licenses/"
+	_cyclonedx_dir="${device_dir}/build/tmp/deploy/cyclonedx/"
+
 	_slug=$(jq --raw-output '.slug' "${_device_type_json}")
 
 	[ -z "${_preserve_build}" ] && rm -rf "${_deploy_dir}"
@@ -88,6 +90,11 @@ balena_deploy_artifacts () {
 	fi
 	if [ -f "$_yocto_build_deploy/kernel_source.tar.gz" ]; then
 		cp -v "$_yocto_build_deploy/kernel_source.tar.gz" "$_deploy_dir" || true
+	fi
+
+	# Compress the sbom and vex files if they exists (there's one of each per target)
+	if [ -d "${_cyclonedx_dir}" ]; then
+		zip -r -j "${_deploy_dir}/sbom+vex.json.zip" "${_cyclonedx_dir}"
 	fi
 
 	# Artifacts with archive: true are bundles of files, so compression is implied

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -49,7 +49,7 @@ balena_deploy_artifacts () {
 	_machine=$(jq --raw-output '.yocto.machine' "${_device_type_json}")
 	_yocto_build_deploy="${device_dir}/build/tmp/deploy/images/${_machine}"
 	_yocto_licenses_deploy="${device_dir}/build/tmp/deploy/licenses/"
-	_cyclonedx_dir="${device_dir}/build/tmp/deploy/cyclonedx"
+	_cyclonedx_dir="${device_dir}/build/tmp/deploy/cyclonedx-export"
 
 	_slug=$(jq --raw-output '.slug' "${_device_type_json}")
 
@@ -94,7 +94,7 @@ balena_deploy_artifacts () {
 
 	# Move sbom and vex files if they exists (there's one of each per target)
 	if [ -d "${_cyclonedx_dir}" ]; then
-		cp -rv "${_cyclonedx_dir}" "${_deploy_dir}"
+		cp -rv "${_cyclonedx_dir}" "${_deploy_dir}/cyclonedx"
 	fi
 
 	# Artifacts with archive: true are bundles of files, so compression is implied

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -49,7 +49,7 @@ balena_deploy_artifacts () {
 	_machine=$(jq --raw-output '.yocto.machine' "${_device_type_json}")
 	_yocto_build_deploy="${device_dir}/build/tmp/deploy/images/${_machine}"
 	_yocto_licenses_deploy="${device_dir}/build/tmp/deploy/licenses/"
-	_cyclonedx_dir="${device_dir}/build/tmp/deploy/cyclonedx/"
+	_cyclonedx_dir="${device_dir}/build/tmp/deploy/cyclonedx"
 
 	_slug=$(jq --raw-output '.slug' "${_device_type_json}")
 
@@ -92,9 +92,9 @@ balena_deploy_artifacts () {
 		cp -v "$_yocto_build_deploy/kernel_source.tar.gz" "$_deploy_dir" || true
 	fi
 
-	# Compress the sbom and vex files if they exists (there's one of each per target)
+	# Move sbom and vex files if they exists (there's one of each per target)
 	if [ -d "${_cyclonedx_dir}" ]; then
-		zip -r -j "${_deploy_dir}/sbom+vex.json.zip" "${_cyclonedx_dir}"
+		cp -rv "${_cyclonedx_dir}" "${_deploy_dir}"
 	fi
 
 	# Artifacts with archive: true are bundles of files, so compression is implied


### PR DESCRIPTION
This is the PR that uploads the SBOM (bom.json) and VEX (vex.json) as release artifacts

https://balena.fibery.io/Work/Project/balenaos-SBOM-as-release-asset-1515

Change-type: minor
Changelog-entry: Generate SBOM and VEX (cycloneDX)