### PR TITLE
upload hostapp artifacts: include encrypted manifest

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -944,6 +944,7 @@ jobs:
             ${{ env.S3_DEPLOY_PATH }}/*.md
             ${{ env.S3_DEPLOY_PATH }}/VERSION*
             ${{ env.S3_DEPLOY_PATH }}/*.manifest
+            ${{ env.S3_DEPLOY_PATH }}/*.manifest.enc
             ${{ env.S3_DEPLOY_PATH }}/licenses.tar.gz
             ${{ env.S3_DEPLOY_PATH }}/cyclonedx/*/*.json
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz


### PR DESCRIPTION
We encrypt the manifest if its private/signed, but don't look for the encrypted version to upload - fixes that

Change-type: patch