### PR TITLE
Dedupe raw or flasher images files during artifact prepare

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1529,6 +1529,13 @@ jobs:
             unzip "${zip}" -d "$(dirname "${zip}")"
           done
 
+          # If balena.img is a symlink, replace it with the file it points to.
+          if [ -L "${DEPLOY_PATH}/image/balena.img" ]; then
+            target_file=$(readlink --canonicalize "${DEPLOY_PATH}/image/balena.img")
+            rm "${DEPLOY_PATH}/image/balena.img"
+            cp "${target_file}" "${DEPLOY_PATH}/image/balena.img"
+          fi
+
       # https://github.com/unfor19/install-aws-cli-action
       # https://github.com/aws/aws-cli/tags
       - name: Setup awscli
@@ -2130,7 +2137,16 @@ jobs:
 
           find "${DEPLOY_PATH}/image" -type f -name "*.img.zip"
 
-          unzip "${DEPLOY_PATH}/image/${BALENA_OS_IMAGE}.zip" -d "${DEPLOY_PATH}/image/"
+          for zip in "${DEPLOY_PATH}"/image/*.img.zip; do
+            unzip "${zip}" -d "$(dirname "${zip}")"
+          done
+
+          # If balena.img is a symlink, replace it with the file it points to.
+          if [ -L "${DEPLOY_PATH}/image/balena.img" ]; then
+            target_file=$(readlink --canonicalize "${DEPLOY_PATH}/image/balena.img")
+            rm "${DEPLOY_PATH}/image/balena.img"
+            cp "${target_file}" "${DEPLOY_PATH}/image/balena.img"
+          fi
 
       # Check out private contracts if this is a private device type - as these are required for the tests
       - name: Checkout private Contracts

--- a/automation/include/balena-deploy.inc
+++ b/automation/include/balena-deploy.inc
@@ -123,12 +123,22 @@ balena_deploy_artifacts () {
 	if [[ -n "${_deploy_flasher_artifact}" ]]; then
 		cp -v "$(readlink --canonicalize "${_yocto_build_deploy}/${_deploy_flasher_artifact}")" \
 			"${_deploy_dir}/image/balena-flasher.img"
+
+		# Deduplicate compressed flasher image files if they are the same source image.
+		if [[ "${_deploy_flasher_artifact}" = "${_deploy_artifact}" ]]; then
+			ln -sfv balena-flasher.img "${_deploy_dir}/image/balena.img"
+		fi
 	fi
 
 	# shellcheck disable=SC2312
 	if [[ -n "${_deploy_raw_artifact}" ]]; then
 		cp -v "$(readlink --canonicalize "${_yocto_build_deploy}/${_deploy_raw_artifact}")" \
 			"${_deploy_dir}/image/balena-raw.img"
+
+		# Deduplicate compressed raw image files if they are the same source image.
+		if [[ "${_deploy_raw_artifact}" = "${_deploy_artifact}" ]]; then
+			ln -sfv balena-raw.img "${_deploy_dir}/image/balena.img"
+		fi
 	fi
 
 	if [[ "${_compressed}" != 'true' ]]; then
@@ -140,6 +150,7 @@ balena_deploy_artifacts () {
 	_zip_flags+=("-v") # verbose operation/print version info
 	_zip_flags+=("-j") # junk (don't record) directory names
 	_zip_flags+=("-9") # compress better
+	_zip_flags+=("-y") # store symbolic links as the link instead of the referenced file
 
 	if [[ "${_remove_compressed_file}" = "true" ]]; then
 		_zip_flags+=("-m") # move into zipfile (delete OS files)


### PR DESCRIPTION
Currently generic device types are uploading 3 images in the test artifacts

balena.img.enc
balena-flasher.img.enc
balena-raw.img.enc

But balena.img is always going to match either the flasher or the raw image depending on the device spec.

This change will replace balena.img(.enc) with a symlink when possible in only the test artifacts to reduce the upload and download size.

Needs to retain support for https://github.com/balena-os/balena-yocto-scripts/pull/640

Testing with generic (MBR) went from 2.68GB to 1.95GB for testing artifacts.