### PR TITLE
upload test artifacts: don't upload all image variants

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -964,9 +964,11 @@ jobs:
           compression-level: 0
           # Look for both the encrypted (.enc) and unencrypted file variants.
           # Do not upload uncompressed .img files as they can be restored from the compressed .zip files after download.
+          # We only care about the main "balena.img" artifact for testing, not the flasher/raw variants, as this is the artifact that will be
+          # uploaded and presented to users.
           path: |
-            ${{ env.S3_DEPLOY_PATH }}/image/*.img.zip
-            ${{ env.S3_DEPLOY_PATH }}/image/*.img.zip.enc
+            ${{ env.S3_DEPLOY_PATH }}/image/balena.img.zip
+            ${{ env.S3_DEPLOY_PATH }}/image/balena.img.zip.enc
             ${{ env.S3_DEPLOY_PATH }}/balena-image.docker
             ${{ env.S3_DEPLOY_PATH }}/balena-image.docker.enc
             ${{ env.S3_DEPLOY_PATH }}/kernel_modules_headers.tar.gz


### PR DESCRIPTION
We only need balena.img, as that is the artifact used in the test. This is to save large amounts of bandwidth for device types such as generic-amd64 which have 3 variants.

Change-type: patch