### PR TITLE
Make release asset upload step required

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -1580,7 +1580,6 @@ jobs:
 
       - name: Upload release assets
         uses: balena-io/upload-balena-release-asset@aa5c76210bde8edc08e21f35c56b05d56fada041 # v0.1.5
-        continue-on-error: true
         with:
           balena-token: ${{ secrets.BALENA_API_DEPLOY_KEY }}
           balena-host: ${{ env.BALENARC_BALENA_URL }}


### PR DESCRIPTION
Release assets are now the primary artifact format and direct S3 is deprecated pending future removal.

Change-type: minor
See: https://balena.fibery.io/Work/Improvement/Duplicate-S3-artifacts-to-web-resources-2983

Relates-to: https://github.com/balena-os/balena-yocto-scripts/pull/858