### PR TITLE
.github/workflows/yocto-build-deploy.yml: Add the rust crates to MIRRORS

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -755,6 +755,7 @@ jobs:
             bzr://.*/.* ${SOURCE_MIRROR_URL} \\
             https?$://.*/.* ${SOURCE_MIRROR_URL} \\
             ftp://.*/.*  ${SOURCE_MIRROR_URL} \\
+            crate://.*/.* ${SOURCE_MIRROR_URL} \\
           "
 
           EOF


### PR DESCRIPTION
Lately fetching the rust crates has been rate limited so let's make sure we add our shared downloaded rust crates to MIRRORS in case we get fetching errors from upstream.

Change-type: patch
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/OS-pipeline-blocked-by-crates.io-rate-limiting-205