### PR TITLE
Pin docker.io to 27.x in yocto-build-env

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -795,6 +795,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y openssh-client
 
+      # Self-CI: wait for Flowzone's bake/publish to push the per-PR helper
+      # image before the Build step tries to pull it. Flowzone runs in parallel
+      # so without this we race the bake job and the pull fails.
+      - name: Wait for helper image
+        if: github.repository == 'balena-os/balena-yocto-scripts' && github.event_name == 'pull_request'
+        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-regexp: "Flowzone / Publish docker .*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success
+          checks-discovery-timeout: 300
+
       # All preperation complete before this step
       # Start building balenaOS
       - name: Build

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -801,6 +801,10 @@ jobs:
         id: build
         env:
           HELPER_IMAGE_REPO: ghcr.io/balena-os/balena-yocto-scripts
+          # Self-CI: use the per-PR helper image baked by Flowzone instead of
+          # the master-tip image. Empty falls through to the VERSION-file
+          # default for downstream device repos that consume this workflow.
+          BALENA_YOCTO_SCRIPTS_VERSION: ${{ github.repository == 'balena-os/balena-yocto-scripts' && github.event_name == 'pull_request' && format('build-{0}', github.event.pull_request.head.sha) || '' }}
           SHARED_BUILD_DIR: ${{ github.workspace }}/shared
           YOCTO_SSH_PRIVATE_KEY_B64: ${{ secrets.YOCTO_SSH_PRIVATE_KEY_B64 }}
           # Use the target deploy environment (balena-cloud.com, balena-staging.com, balena-dev.com...) to
@@ -839,6 +843,10 @@ jobs:
         env:
           automation_dir: "${{ github.workspace }}/balena-yocto-scripts/automation"
           HELPER_IMAGE_REPO: ghcr.io/balena-os/balena-yocto-scripts
+          # Self-CI: use the per-PR helper image baked by Flowzone instead of
+          # the master-tip image. Empty falls through to the VERSION-file
+          # default for downstream device repos that consume this workflow.
+          BALENA_YOCTO_SCRIPTS_VERSION: ${{ github.repository == 'balena-os/balena-yocto-scripts' && github.event_name == 'pull_request' && format('build-{0}', github.event.pull_request.head.sha) || '' }}
           SHARED_BUILD_DIR: ${{ github.workspace }}/shared
           SIGN_KMOD_KEY_APPEND: "${{ secrets.SIGN_KMOD_KEY_APPEND }}"
           INSTALL_DIR: /work

--- a/automation/Dockerfile_yocto-build-env
+++ b/automation/Dockerfile_yocto-build-env
@@ -24,10 +24,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends jq nodejs npm s
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends dos2unix && rm -rf /var/lib/apt/lists/*
 
-# Install docker matching the balena-engine version
-# https://docs.docker.com/engine/install/ubuntu/
+# Install docker — pinned to docker.io 27.x, the newest major in jammy that
+# still accepts API-1.41 clients (Docker 29.x raised MIN_API_VERSION from 1.24
+# to 1.44, breaking the docker client used by mkfs-hostapp-native:do_compile).
+# Wildcard absorbs Ubuntu's future security patches within the 27.x line.
+# Re-evaluate when balena-engine moves to a newer major; jammy ships only
+# 20.10 / 27.5 / 29.1 of docker.io, so switch to docker-ce from Docker's
+# official APT repo for anything else: https://docs.docker.com/engine/install/ubuntu/
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release docker.io && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release "docker.io=27.*" && rm -rf /var/lib/apt/lists/*
 VOLUME /var/lib/docker
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

- Ubuntu pushed `docker.io 29.1.3` to `jammy-updates` very recently. Docker 29.x bumps the daemon's minimum supported client API from 1.24 → 1.44, dropping any client < Docker 25.x.
- The yocto-build-env image's `apt-get install docker.io` is unpinned, so each rebuild pulls the highest version across enabled pockets. Released image tags before `v1.39.32` baked `docker.io 28.2.2` (which still accepted API-1.41 clients). `v1.39.32` (built today) and any dev-branch image rebuilt in the last few days bake `29.1.3` — which rejects the API-1.41 client invoked by `mkfs-hostapp-native:do_compile`.
- Dev-branch CI started failing 2-3 days ago because Flowzone rebuilds the helper image fresh per branch and was the first thing to pick up Ubuntu's `29.1.3` push. Released device pipelines pinned to `v1.39.31` are still on `28.2.2` and unaffected — but as soon as anything moves to `v1.39.32`, they'd break too.
- Pin `docker.io=27.*` — the newest major in jammy that still accepts API-1.41 clients (currently resolves to `27.5.1-0ubuntu3~22.04.2` from `jammy-security`). The wildcard absorbs Ubuntu's future security patches within the 27.x line without re-introducing the regression.

## Bisection: docker.io version per published yocto-build-env tag

Pulled each tag and ran `dpkg -l docker.io`:

| Tag       | Image build date | docker.io version       |
|-----------|------------------|-------------------------|
| 1.39.10   | 2026-01-27       | 28.2.2-0ubuntu1~22.04.1 |
| 1.39.20   | 2026-01-27       | 28.2.2-0ubuntu1~22.04.1 |
| 1.39.29   | 2026-03-27       | 28.2.2-0ubuntu1~22.04.1 |
| 1.39.31   | 2026-04-02       | 28.2.2-0ubuntu1~22.04.1 |
| **1.39.32** | **2026-04-30**   | **29.1.3-0ubuntu3~22.04.1** |

The Dockerfile hasn't materially changed in months — recent commits are all renovate balena-cli bumps. The variability is entirely in apt resolution at build time.

Current `apt-cache policy docker.io` on `ubuntu:22.04`:

```
docker.io:
  Candidate: 29.1.3-0ubuntu3~22.04.1
  Version table:
     29.1.3-0ubuntu3~22.04.1 500  jammy-updates/universe    <-- new, breaks API 1.41 clients (Docker 29 raised MIN_API)
     27.5.1-0ubuntu3~22.04.2 500  jammy-security/universe   <-- this PR pins here via =27.* wildcard
     20.10.12-0ubuntu4       500  jammy/universe
```
