### PR TITLE
yocto-build-deploy: normalize placeholders, soft-skip schema validation

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -406,7 +406,7 @@ jobs:
                 io.balena.image.store: 'root'
                 io.balena.image.class: 'hostapp'
                 io.balena.update.requires-reboot: '1'
-                io.balena.private.hostapp.board-rev: '$DEVICE_REPO_REV'
+                io.balena.private.hostapp.board-rev: '__DEVICE_REPO_REV__'
           COMPEOF
           fi
 
@@ -1740,11 +1740,12 @@ jobs:
             done
           fi
 
-          # Replace literal "$DEVICE_REPO_REV" placeholder values with the env value.
+          # Replace literal "__DEVICE_REPO_REV__" placeholder values with the env value.
           # yq's recursive descent + select(. == ...) matches whole node values only — immune to
           # substring collisions in other label values, unlike envsubst which is a regex pass.
+          # See docs/specs/hostapp-composition.md#placeholders for the contract.
           : "${DEVICE_REPO_REV:?required for hostapp board-rev label substitution}"
-          yq -i '(.. | select(. == "$DEVICE_REPO_REV")) = strenv(DEVICE_REPO_REV)' "${WORKSPACE}/docker-compose.yml"
+          yq -i '(.. | select(. == "__DEVICE_REPO_REV__")) = strenv(DEVICE_REPO_REV)' "${WORKSPACE}/docker-compose.yml"
 
           echo "[INFO] Final composition:"
           cat "${WORKSPACE}/docker-compose.yml"

--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -424,11 +424,17 @@ jobs:
           COMPOSITION="${MACHINE}.hostapp.yml"
           SCHEMA="balena-yocto-scripts/schemas/hostapp-composition.json"
 
-          # Structural validation: compose-spec compliance + x-build shape.
-          # Catches typos (x-buld), wrong types (recipe: 42), unknown fields inside x-build.
-          # Semantic rules (recipe uniqueness, build_slot/x-build pairing) live in the yq checks below.
-          pipx install check-jsonschema >/dev/null 2>&1 || pip install --user --quiet check-jsonschema
-          check-jsonschema --schemafile "${SCHEMA}" "${COMPOSITION}"
+          # Soft-skip if the submodule pointer predates the schema file. Once device repos bump their
+          # balena-yocto-scripts submodule to a ref that contains schemas/, validation activates automatically.
+          if [ ! -f "${SCHEMA}" ]; then
+            echo "::warning title=Schema not available::${SCHEMA} not found in the checkout — structural validation skipped. Update the balena-yocto-scripts submodule pointer to enable it."
+          else
+            # Structural validation: compose-spec compliance + x-build shape.
+            # Catches typos (x-buld), wrong types (recipe: 42), unknown fields inside x-build.
+            # Semantic rules (recipe uniqueness, build_slot/x-build pairing) live in the yq checks below.
+            pipx install check-jsonschema >/dev/null 2>&1 || pip install --user --quiet check-jsonschema
+            check-jsonschema --schemafile "${SCHEMA}" "${COMPOSITION}"
+          fi
 
           # Reject empty/missing services upfront — downstream yq queries return [] silently otherwise.
           n_services=$(yq '.services // {} | length' "${COMPOSITION}")

--- a/docs/specs/hostapp-composition.md
+++ b/docs/specs/hostapp-composition.md
@@ -44,8 +44,11 @@ autocomplete on `x-build` fields and inline diagnostics for typos and wrong
 types.
 
 The workflow's "Validate composition" step also runs `check-jsonschema`
-against this schema as a hard CI gate, before the yq-based semantic checks.
-The two layers are deliberate:
+against the schema bundled in the `balena-yocto-scripts` submodule, before
+the yq-based semantic checks. The check soft-skips with a `::warning::`
+annotation if the submodule pointer predates the schema file — once a device
+repo bumps its submodule, validation activates automatically. The two layers
+are deliberate:
 
 - **Schema** catches structural errors — typos (`x-buld`), wrong types
   (`recipe: 42`), unknown nested fields inside `x-build`. Declarative,

--- a/docs/specs/hostapp-composition.md
+++ b/docs/specs/hostapp-composition.md
@@ -86,7 +86,7 @@ services:
       io.balena.image.store: "root"
       io.balena.image.class: "hostapp"
       io.balena.update.requires-reboot: "1"
-      io.balena.private.hostapp.board-rev: "$DEVICE_REPO_REV"
+      io.balena.private.hostapp.board-rev: "__DEVICE_REPO_REV__"
 ```
 
 A device overlay adds extensions:
@@ -150,16 +150,35 @@ scope:
   matrix. Without a concrete `image:`, this combination fails the composition
   validation.
 
-## Image field substitution
+## Placeholders
 
-Built services declare `image: __BUILD_OUTPUT__` as a sentinel. The workflow
-overwrites the sentinel at deploy time with the image reference returned by
-`docker load`. Services with concrete `image:` values are passed through
-unchanged.
+The composition supports two **workflow-time placeholders** that the deploy
+step rewrites before passing the composition to `balena deploy`. Both follow
+the `__UPPERCASE_SNAKE__` form to stay visually distinct from real values and
+to avoid collision with [compose-spec variable
+interpolation](https://github.com/compose-spec/compose-spec/blob/master/12-interpolation.md)
+(`$VAR` / `${VAR}`), which compose parsers may apply before our substitution
+step runs.
 
-After substitution, the workflow validates that no `__BUILD_OUTPUT__`
-placeholders remain. A surviving placeholder means an extension archive failed
-to match a service; the deploy fails fast.
+| Placeholder           | Valid in         | Resolves to                                                                                    |
+| --------------------- | ---------------- | ---------------------------------------------------------------------------------------------- |
+| `__BUILD_OUTPUT__`    | service `image:` | The image reference returned by `docker load` for that service's built `.docker` archive.      |
+| `__DEVICE_REPO_REV__` | any string value | The device repo's git revision (exposed to the deploy step via the `DEVICE_REPO_REV` env var). |
+
+`__BUILD_OUTPUT__` is matched structurally by path (`.services.<svc>.image`) —
+services with concrete `image:` values are passed through unchanged. After
+substitution, the workflow validates that no `__BUILD_OUTPUT__` remains; a
+surviving sentinel means an extension archive failed to match a service and
+the deploy fails fast.
+
+`__DEVICE_REPO_REV__` is matched by whole-node string equality at any depth
+in the composition, so it's immune to substring collisions in other label
+values. The workflow's `${DEVICE_REPO_REV:?...}` guard fails fast if the
+env var is unset, preventing silent empty-string substitution.
+
+Adding a new placeholder is a three-step contract change: this section, the
+workflow's substitution step, and any meta-balena base composition or device
+overlay that emits the placeholder.
 
 ## Image labels
 
@@ -177,7 +196,7 @@ How labels reach the image is the recipe's choice — `docker import --change`, 
 is agnostic to the mechanism; it only requires the produced image carries the
 labels its consumers expect. The composition is the right place for labels that
 need workflow-time substitution (e.g.,
-`io.balena.private.hostapp.board-rev: '$DEVICE_REPO_REV'`).
+`io.balena.private.hostapp.board-rev: '__DEVICE_REPO_REV__'`).
 
 See [Image Labels Reference](../reference/image-labels.md) for the full catalog
 and consumer table.


### PR DESCRIPTION
Two follow-ups to #895 before downstream adopters need them.

**Normalize composition placeholders to `__VAR__` form.** `$DEVICE_REPO_REV`
followed compose-spec's variable interpolation syntax (`$VAR` / `${VAR}`),
which would silently interpolate to empty if any future compose parser in
the deploy path enables it. `__DEVICE_REPO_REV__` is syntactically inert.

**Soft-skip the JSON Schema check when the bundled schema isn't in the checkout.**
Device repos haven't all bumped their `balena-yocto-scripts` submodule pointer
to a ref containing `schemas/hostapp-composition.json` yet. Skip with a
`::warning::` annotation; validation activates automatically once they bump.

Also adds a Placeholders section to the spec.

See: https://balena.fibery.io/Work/Improvement/Extensions-build-pipeline-changes-4332
