### PR TITLE
yocto-build-deploy: replace pattern based all history first parent match

### DIFF
--- a/.github/workflows/yocto-build-deploy.yml
+++ b/.github/workflows/yocto-build-deploy.yml
@@ -642,8 +642,13 @@ jobs:
         id: set-merge-commit
         if: ${{ github.event_name == 'push' }} # Only perform on push event - i.e a new version tag
         run: |
-          merge_commit=$(git rev-parse :/"^Merge pull request")
-          echo "Found merge commit ${merge_commit}"
+          set -euo pipefail
+          merge_commit=$(git log --first-parent --format='%H %s' | grep -m1 -E '#[0-9]+' | cut -d' ' -f1 || true)
+          if [ -z "${merge_commit}" ]; then
+            echo "::error title=No PR commit found::Could not find a commit referencing a PR in the first-parent history of $(git rev-parse HEAD)"
+            exit 1
+          fi
+          echo "Found merge commit ${merge_commit}: $(git log -1 --format='%s' "${merge_commit}")"
           echo "merge_commit=${merge_commit}" >>"${GITHUB_OUTPUT}"
 
       # This will control the deployment of the hostapp only - it will determine if it is marked as final or not


### PR DESCRIPTION
Instead, resolve the PR commit by walking the pushed ref's own first-parent history.

Pattern search returns the youngest match reachable from ANY ref, so it can jump onto an unrelated branch (e.g. an ESR PR) whose commit is not even an ancestor of this tag.

Also,  match any `#<num>` instead of the literal "Merge pull request" prefix, so squash merged and custom titled merges
(like "Update GitHub Actions (#759)") are found, but not version-bump commits made by bots.

Change-type: patch