### PR TITLE
hostapp-composition(overlays): extend schema to check for runtime

### DIFF
--- a/docs/specs/hostapp-composition.md
+++ b/docs/specs/hostapp-composition.md
@@ -119,6 +119,11 @@ builds via `balena-kernel-modules-block`.
 | `build_args` | list of strings | no       | Extra barys arguments specific to this service. Joined with spaces and appended to common args.  |
 | `assets`     | list of strings | no       | Globs of raw build outputs under `build/tmp/deploy/`; transformed to flat keys on deploy.        |
 
+### Overlay services name their runtime
+
+A service labelled `io.balena.image.class: overlay` must declare compose-spec's
+`runtime`, and the schema requires it.
+
 ### Opt-out signals
 
 A device overlay opts out of base-composition services by setting keys to null

--- a/schemas/hostapp-composition.json
+++ b/schemas/hostapp-composition.json
@@ -15,7 +15,25 @@
             "type": "object",
             "properties": {
               "x-build": { "$ref": "#/$defs/x-build" }
-            }
+            },
+            "allOf": [
+              {
+                "$comment": "An overlay runs under a named OCI runtime.",
+                "if": {
+                  "properties": {
+                    "labels": {
+                      "type": "object",
+                      "properties": {
+                        "io.balena.image.class": { "const": "overlay" }
+                      },
+                      "required": ["io.balena.image.class"]
+                    }
+                  },
+                  "required": ["labels"]
+                },
+                "then": { "required": ["runtime"] }
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
An image declaring io.balena.image.class as overlay needs to define what runtime to use.

Relates-to: https://balena.fibery.io/Work/Project/Hostapp-extensions---profile-and-rollback-support-2835